### PR TITLE
Intercept Lightning URIs

### DIFF
--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -1,6 +1,7 @@
 import 'babel-polyfill';
 import shouldInject from './shouldInject';
 import injectScript from './injectScript';
+import { PROMPT_TYPE } from '../webln/types';
 
 if (shouldInject()) {
   injectScript();
@@ -20,6 +21,30 @@ if (shouldInject()) {
           data: response.data,
         }, '*');
       });
+    }
+  });
+}
+
+// Intercept any `lightning:{paymentReqest}` requests
+// TODO: Get ts to type this function
+if (document && document.body) {
+  document.body.addEventListener('click', (ev) => {
+    const target = ev.target as HTMLElement;
+    if (!target || !target.closest) {
+      return;
+    }
+
+    const lightningLink = target.closest('[href^="lightning:"]');
+    if (lightningLink) {
+      const href = lightningLink.getAttribute('href') as string;
+      const paymentRequest = href.replace('lightning:', '');
+      chrome.runtime.sendMessage({
+        application: 'Joule',
+        prompt: true,
+        type: PROMPT_TYPE.PAYMENT,
+        args: { paymentRequest },
+      });
+      ev.preventDefault();
     }
   });
 }


### PR DESCRIPTION
Closes #10. Very simple document click selector. I'd like to have used something more sophisticated like the extension webRequest API, but there is **_no support_** for custom protocols. So alas, here we are.