### PR TITLE
Deposit address modal

### DIFF
--- a/src/app/components/AccountInfo/DepositModal.less
+++ b/src/app/components/AccountInfo/DepositModal.less
@@ -1,11 +1,21 @@
 .DepositModal {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 0 2rem;
+  text-align: center;
 
   &-qr {
-    margin-bottom: 1rem;
+    margin: 0 auto 0.5rem;
+  }
+
+  &-address {
+    font-size: 0.6rem;
+    opacity: 0.7;
+    padding: 0.5rem;
+    word-wrap: break-word;
+    border-radius: 4px;
+    background: rgba(#000, 0);
+
+    &:hover {
+      cursor: pointer;
+      background: rgba(#000, 0.06);
+    }
   }
 }

--- a/src/app/components/Copy.tsx
+++ b/src/app/components/Copy.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { message } from 'antd';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+
+interface Props {
+  children: React.ReactNode;
+  text: string;
+  name?: string;
+}
+
+export default class Copy extends React.Component<Props> {
+  render() {
+    const { children, text, name } = this.props;
+    const msg = name ? `Copied ${name} to clipboard` : 'Copied to clipboard';
+
+    return (
+      <CopyToClipboard text={text} onCopy={() => message.success(msg, 1.5)}>
+        {children}
+      </CopyToClipboard>
+    )
+  }
+}

--- a/src/app/components/PasswordPrompt/index.tsx
+++ b/src/app/components/PasswordPrompt/index.tsx
@@ -53,6 +53,7 @@ class PasswordPrompt extends React.Component<Props, State> {
                 value={password}
                 onChange={this.handleChange}
                 enterButton={<Icon type="unlock" />}
+                onSearch={() => this.handleSubmit()}
                 autoFocus
               />
             </Form.Item>
@@ -69,8 +70,10 @@ class PasswordPrompt extends React.Component<Props, State> {
     });
   };
 
-  private handleSubmit = (ev: React.FormEvent<HTMLFormElement>) => {
-    ev.preventDefault();
+  private handleSubmit = (ev?: React.FormEvent<HTMLFormElement>) => {
+    if (ev) {
+      ev.preventDefault();
+    }
     const { password } = this.state;
     const { testCipher, salt } = this.props;
     try {

--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -191,7 +191,7 @@ export class LndHttpClient {
     return this.request<T.NewAddressResponse, T.NewAddressArguments>(
       'GET',
       '/v1/newaddress',
-      { type },
+      // { type },
     );
   };
 

--- a/src/app/modules/account/actions.ts
+++ b/src/app/modules/account/actions.ts
@@ -7,3 +7,7 @@ export function getAccountInfo() {
 export function getTransactions() {
   return { type: types.GET_TRANSACTIONS };
 }
+
+export function getDepositAddress() {
+  return { type: types.GET_DEPOSIT_ADDRESS };
+}

--- a/src/app/modules/account/reducers.ts
+++ b/src/app/modules/account/reducers.ts
@@ -6,10 +6,13 @@ export interface AccountState {
   payments: LightningPayment[] | null;
   invoices: LightningInvoice[] | null;
   transactions: BitcoinTransaction[] | null;
+  depositAddress: string | null;
   isFetchingAccountInfo: boolean;
   fetchAccountInfoError: null | Error;
   isFetchingTransactions: boolean;
   fetchTransactionsError: null | Error;
+  isFetchingDepositAddress: boolean;
+  fetchDepositAddressError: null | Error;
 }
 
 export const INITIAL_STATE: AccountState = {
@@ -17,10 +20,13 @@ export const INITIAL_STATE: AccountState = {
   payments: null,
   invoices: null,
   transactions: null,
+  depositAddress: null,
   isFetchingAccountInfo: false,
   fetchAccountInfoError: null,
   isFetchingTransactions: false,
   fetchTransactionsError: null,
+  isFetchingDepositAddress: false,
+  fetchDepositAddressError: null,
 };
 
 export default function channelsReducers(
@@ -69,6 +75,26 @@ export default function channelsReducers(
         fetchTransactionsError: action.payload,
         isFetchingTransactions: false,
       }
+    
+    case types.GET_DEPOSIT_ADDRESS:
+      return {
+        ...state,
+        depositAddress: null,
+        fetchDepositAddressError: null,
+        isFetchingDepositAddress: true,
+      };
+    case types.GET_DEPOSIT_ADDRESS_SUCCESS:
+      return {
+        ...state,
+        depositAddress: action.payload,
+        isFetchingDepositAddress: true,
+      };
+    case types.GET_DEPOSIT_ADDRESS_FAILURE:
+      return {
+        ...state,
+        fetchDepositAddressError: action.payload,
+        isFetchingDepositAddress: false,
+      };
   }
 
   return state;

--- a/src/app/modules/account/types.ts
+++ b/src/app/modules/account/types.ts
@@ -8,6 +8,10 @@ enum AccountTypes {
   GET_TRANSACTIONS = 'GET_TRANSACTIONS',
   GET_TRANSACTIONS_SUCCESS = 'GET_TRANSACTIONS_SUCCESS',
   GET_TRANSACTIONS_FAILURE = 'GET_TRANSACTIONS_FAILURE',
+
+  GET_DEPOSIT_ADDRESS = 'GET_DEPOSIT_ADDRESS',
+  GET_DEPOSIT_ADDRESS_SUCCESS = 'GET_DEPOSIT_ADDRESS_SUCCESS',
+  GET_DEPOSIT_ADDRESS_FAILURE = 'GET_DEPOSIT_ADDRESS_FAILURE',
 }
 
 export default AccountTypes;
@@ -20,7 +24,6 @@ export interface Account {
   blockchainBalancePending: number;
   channelBalance: number;
   channelBalancePending: number;
-  chainAddress: string;
 }
 
 export type AnyTransaction =

--- a/src/app/modules/payment/sagas.ts
+++ b/src/app/modules/payment/sagas.ts
@@ -8,7 +8,6 @@ import types from './types';
 export function* handleSendPayment(action: ReturnType<typeof sendPayment>): SagaIterator {
   try {
     yield call(requirePassword);
-    console.log('Continuing');
     const nodeLib: Yielded<typeof selectNodeLibOrThrow> = yield select(selectNodeLibOrThrow);
     const payload = yield call(nodeLib.sendPayment, action.payload);
     yield put({

--- a/src/app/typings/react-copy-to-clipboard.d.ts
+++ b/src/app/typings/react-copy-to-clipboard.d.ts
@@ -1,0 +1,14 @@
+declare module 'react-copy-to-clipboard' {
+  interface Options {
+    debug: boolean;
+    message: string;
+  }
+
+  interface Props {
+    text: string;
+    onCopy?(a: string, b: boolean): void;
+    options?: Options;
+  }
+
+  export class CopyToClipboard extends React.Component<Props> {}
+}


### PR DESCRIPTION
Implements the deposit address modal. Unfortunately getting at the address is behind the admin macaroon, for some reason, so it requires a password entry.

Somewhere along the way I fixed #20 as well.

<img width="378" alt="screen shot 2018-11-01 at 12 06 59 am" src="https://user-images.githubusercontent.com/649992/47832120-13027480-dd6a-11e8-96e9-bce8139a6220.png">

<sup>Feel free to uh, deposit some BTC to that one if you'd like.</sup>