### PR TITLE
SSL cert error instructions

### DIFF
--- a/src/app/components/SelectNode/InputAddress.less
+++ b/src/app/components/SelectNode/InputAddress.less
@@ -3,7 +3,12 @@
   max-width: 440px;
   margin: 0 auto;
 
-  .ant-form-item {
+  .ant-form-item,
+  .ant-alert {
     margin-bottom: 1rem;
+  }
+
+  .ant-alert a {
+    text-decoration: underline;
   }
 }

--- a/src/app/components/SelectNode/index.tsx
+++ b/src/app/components/SelectNode/index.tsx
@@ -63,7 +63,7 @@ class SelectNode extends React.Component<Props, State> {
     let content: React.ReactNode;
     let title: React.ReactNode;
     if (nodeType) {
-      if (isCheckingNode || isCheckingAuth) {
+      if (isCheckingAuth) {
         content = <Spin />;
       }
       else if (nodeInfo) {
@@ -86,6 +86,7 @@ class SelectNode extends React.Component<Props, State> {
           <InputAddress
             submitUrl={this.setUrl}
             error={checkNodeError}
+            isCheckingNode={isCheckingNode}
           />
         );
       }


### PR DESCRIPTION
Closes #19.

### What This Does

Improves the experience for users connecting to nodes (mainly local) that have self-signed certificates. It displays some text that explains what the error may be, and how to solve it. Unfortunately, there is no granularity to the information of why a requests failed (We just get "TypeError: Failed to fetch" which is the same error you get for many reasons.) So we just display the help text no matter what.

It's also worth noting that the instructions @brandoncurtis provided in #19 seemed to be OS-specific, so I went for the quick-and-easy approach of just telling the user to have the browser ignore the cert issue.

Ideally, this issue will be solvable in the future with either better extension permissions (Just ignore the cert error) or some better ssl cert procedure during lnd setup.

## Screenshots

<img width="450" alt="screen shot 2018-11-12 at 11 49 27 pm" src="https://user-images.githubusercontent.com/649992/48391752-1b49a080-e6d6-11e8-9e10-f1affdd91980.png">
