### PR TITLE
Better balances

### DIFF
--- a/src/app/components/AccountInfo/index.tsx
+++ b/src/app/components/AccountInfo/index.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { Button, Icon } from 'antd';
 import { ButtonProps } from 'antd/lib/button';
 import Identicon from 'components/Identicon';
+import Unit from 'components/Unit';
 import DepositModal from './DepositModal';
 import { getAccountInfo } from 'modules/account/actions';
 import { AppState } from 'store/reducers';
@@ -66,11 +67,11 @@ class AccountInfo extends React.Component<Props, State> {
             <div className="AccountInfo-top-info">
               <div className="AccountInfo-top-info-alias">{account.alias}</div>
               <div className="AccountInfo-top-info-balance">
-                {account.channelBalance} sats
+                <Unit value={account.totalBalance} />
               </div>
               <div className="AccountInfo-top-info-balances">
-                <span>Bitcoin: {account.blockchainBalance} sats</span>
-                <span>Channels: {account.channelBalance} sats</span>
+                <span>Channels: <Unit value={account.channelBalance} /></span>
+                <span>Bitcoin: <Unit value={account.blockchainBalance} /></span>
               </div>
             </div>
           </div>

--- a/src/app/components/AccountInfo/style.less
+++ b/src/app/components/AccountInfo/style.less
@@ -19,21 +19,23 @@
 
     &-info {
       &-alias {
+        margin-top: -0.2rem;
         font-size: 1.2rem;
         font-weight: bold;
       }
 
       &-balance {
         font-size: 1rem;
+        margin-bottom: 0.1rem;
       }
 
       &-balances {
         display: flex;
-        font-size: 0.8rem;
+        font-size: 0.7rem;
         opacity: 0.8;
         
         > * {
-          margin-right: 1rem;
+          margin-right: 0.75rem;
 
           &:last-child {
             margin: 0;

--- a/src/app/components/ChannelList/ChannelRow.less
+++ b/src/app/components/ChannelList/ChannelRow.less
@@ -24,13 +24,20 @@
     &-alias {
       font-weight: 500;
       font-size: 0.95rem;
+      margin-bottom: 0.1rem;
     }
     
     &-pubkey {
       font-size: 0.65rem;
+      margin-bottom: 0.15rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+
+    &-balance {
+      font-size: 0.7rem;
+      opacity: 0.8;
     }
   }
 }

--- a/src/app/components/ChannelList/ChannelRow.tsx
+++ b/src/app/components/ChannelList/ChannelRow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import Identicon from 'components/Identicon';
+import Unit from 'components/Unit';
 import { ChannelWithNode } from 'modules/channels/types';
 import './ChannelRow.less';
 
@@ -28,12 +29,10 @@ export default class ChannelRow extends React.Component<Props> {
           <div className="ChannelRow-info-pubkey">
             <code>{channel.node.pub_key}</code>
           </div>
-          <div className="ChannelRow-info-stuff">
-            {channel.capacity}
-            {' · '}
-            {channel.remote_balance}
-            {' · '}
-            {channel.local_balance}
+          <div className="ChannelRow-info-balance">
+            Balance: <Unit value={channel.local_balance} hideUnit />
+            {' / '}
+            <Unit value={channel.capacity} />
           </div>
         </div>
       </div>

--- a/src/app/components/TransactionList/TransactionRow.tsx
+++ b/src/app/components/TransactionList/TransactionRow.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import classnames from 'classnames';
 import { Tooltip, Icon } from 'antd';
 import Identicon from 'components/Identicon';
+import Unit from 'components/Unit';
 import { AnyTransaction } from 'modules/account/types';
 import { isInvoice, isBitcoinTx } from 'utils/typeguards';
 import BitcoinLogo from 'static/images/bitcoin.svg';
@@ -63,7 +64,7 @@ export default class TransactionRow extends React.Component<Props> {
           <div className={
             classnames(`TransactionRow-delta is-${delta.gtn(0) ? 'positive' : 'negative'}`)
           }>
-            {delta.gtn(0) && '+'}{delta.toString()} sats
+            {delta.gtn(0) && '+'}<Unit value={delta.toString()} />
           </div>
         }
       </div>

--- a/src/app/components/TransactionList/index.tsx
+++ b/src/app/components/TransactionList/index.tsx
@@ -109,8 +109,6 @@ class TransactionList extends React.Component<Props> {
       invoices.map(invoice => {
         const timestamp = parseInt(invoice.creation_date, 10);
         const expiry = timestamp + parseInt(invoice.expiry, 10);
-        console.log(expiry);
-        console.log(Date.now() / 1000);
         const status = invoice.settled ? 'complete' :
           expiry < Date.now() / 1000 ? 'expired' : 'pending';
 

--- a/src/app/components/Unit.tsx
+++ b/src/app/components/Unit.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 
 interface Props {
   value: string;
+  hideUnit?: boolean;
 }
 
-const Unit: React.SFC<Props> = ({ value }) => (
-  <span>{value} sats</span>
+const commaify = (num: string) => num.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+const Unit: React.SFC<Props> = ({ value, hideUnit }) => (
+  <span>{commaify(value)} {!hideUnit && 'sats'}</span>
 );
 
 export default Unit;

--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -98,7 +98,13 @@ export class LndHttpClient {
       '/v1/transactions',
       undefined,
       { transactions: [] },
-    );
+    ).then(res => {
+      res.transactions = res.transactions.map(tx => ({
+        total_fees: '0',
+        ...tx,
+      }));
+      return res;
+    });
   };
 
   getPayments = () => {
@@ -109,8 +115,8 @@ export class LndHttpClient {
       { payments: [] },
     ).then(res => {
       res.payments = res.payments.map(t => ({
-        ...t,
         fee: '0',
+        ...t,
       }));
       return res;
     });;

--- a/src/app/modules/account/sagas.ts
+++ b/src/app/modules/account/sagas.ts
@@ -1,5 +1,6 @@
 import { SagaIterator } from 'redux-saga';
 import { takeLatest, select, call, all, put } from 'redux-saga/effects';
+import BN from 'bn.js';
 import { selectNodeLibOrThrow } from 'modules/node/selectors';
 import { getNodePubKey } from 'modules/node/sagas';
 import { requirePassword } from 'modules/crypto/sagas';
@@ -23,6 +24,12 @@ export function* handleGetAccountInfo(): SagaIterator {
       blockchainBalancePending: chainBalances.total_balance,
       channelBalance: channelsBalances.balance,
       channelBalancePending: channelsBalances.pending_open_balance,
+      totalBalance: new BN(chainBalances.confirmed_balance).add(
+        new BN(channelsBalances.balance)
+      ).toString(),
+      totalBalancePending: new BN(chainBalances.total_balance).add(
+        new BN(channelsBalances.pending_open_balance)
+      ).toString(),
     };
     yield put({
       type: types.GET_ACCOUNT_INFO_SUCCESS,

--- a/src/app/modules/account/types.ts
+++ b/src/app/modules/account/types.ts
@@ -20,10 +20,12 @@ export interface Account {
   pubKey: string;
   alias: string;
   color: string;
-  blockchainBalance: number;
-  blockchainBalancePending: number;
-  channelBalance: number;
-  channelBalancePending: number;
+  blockchainBalance: string;
+  blockchainBalancePending: string;
+  channelBalance: string;
+  channelBalancePending: string;
+  totalBalance: string;
+  totalBalancePending: string;
 }
 
 export interface LightningPaymentWithToNode extends LightningPayment {

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -38,7 +38,7 @@ export default class HomePage extends React.Component<{}, State> {
             tab={<><Icon type="fork"/> Channels</>}
             key="channels"
           >
-            <ChannelList onClick={this.handleChannelClick} />
+            <ChannelList /*onClick={this.handleChannelClick}*/ />
           </Tabs.TabPane>
           <Tabs.TabPane
             tab={<><Icon type="shopping"/> Transactions</>}
@@ -92,9 +92,9 @@ export default class HomePage extends React.Component<{}, State> {
     this.openDrawer(<InvoiceForm close={this.closeDrawer} />, 'Create Invoice');
   };
 
-  private handleChannelClick = (channel: ChannelWithNode) => {
-    this.openDrawer(<h1>{channel.node.alias}</h1>)
-  };
+  // private handleChannelClick = (channel: ChannelWithNode) => {
+  //   this.openDrawer(<h1>{channel.node.alias}</h1>)
+  // };
 
   private handleTransactionClick = (tx: AnyTransaction) => {
     this.openDrawer(<TransactionInfo tx={tx} />, 'Transaction Details');

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -6,7 +6,7 @@ import TransactionList from 'components/TransactionList';
 import SendForm from 'components/SendForm';
 import InvoiceForm from 'components/InvoiceForm';
 import TransactionInfo from 'components/TransactionInfo';
-import { ChannelWithNode } from 'modules/channels/types';
+// import { ChannelWithNode } from 'modules/channels/types';
 import { AnyTransaction } from 'modules/account/types';
 import './home.less';
 


### PR DESCRIPTION
Mostly prep-work for #3 & #4, wraps most components in the `<Unit/>` component and comma-ifies them. Somewhat improves the interface of channel balances.

Also temporarily disables the unfunctioning channel drawer on click, since it wasn't doing anything. That'll be re-added in full with a future PR.

<img width="380" alt="screen shot 2018-11-17 at 12 29 52 pm" src="https://user-images.githubusercontent.com/649992/48663878-842d7180-ea64-11e8-9818-3e7f3b3eb2e5.png">
