### PR TITLE
Reset connection settings

### DIFF
--- a/src/app/components/Settings/index.tsx
+++ b/src/app/components/Settings/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Form, Select, Checkbox } from 'antd';
+import { withRouter, RouteComponentProps } from 'react-router';
+import { Form, Select, Checkbox, Button, Modal } from 'antd';
 import { SelectValue } from 'antd/lib/select';
 import { CheckboxChangeEvent } from 'antd/lib/checkbox';
-import { changeSettings } from 'modules/settings/actions';
+import { changeSettings, clearSettings } from 'modules/settings/actions';
 import {
   Denomination,
   Fiat,
@@ -23,9 +24,10 @@ interface StateProps {
 
 interface DispatchProps {
   changeSettings: typeof changeSettings;
+  clearSettings: typeof clearSettings;
 }
 
-type Props = StateProps & DispatchProps;
+type Props = StateProps & DispatchProps & RouteComponentProps;
 
 class Settings extends React.Component<Props> {
   render() {
@@ -82,7 +84,6 @@ class Settings extends React.Component<Props> {
           </Form.Item>
         </div>
 
-        {/*
         <div className="Settings-section">
           <h3 className="Settings-section-title">
             Node
@@ -92,12 +93,11 @@ class Settings extends React.Component<Props> {
             size="large"
             block
             ghost
-            onClick={this.clearNode}
+            onClick={this.clearSettings}
           >
-            Clear node connection settings
+            Reset password and connection settings
           </Button>
         </div>
-        */}
       </Form>
     );
   }
@@ -112,26 +112,29 @@ class Settings extends React.Component<Props> {
     })
   };
 
-  /*private clearNode = () => {
+  private clearSettings = () => {
     Modal.confirm({
       title: 'Are you sure?',
       content: `
         You will be returned to the starting screen and be required to
-        re-enter your node connection settings to return. All other settings
-        will remain unchanged.
+        re-enter your node connection settings and a new password to return.
+        All other settings will remain unchanged.
       `,
-      onOk() {
-        console.log('Cleared');
+      onOk: () => {
+        this.props.clearSettings();
       },
     });
-  };*/
+  };
 }
 
 const ConnectedSettings = connect<StateProps, DispatchProps, {}, AppState>(
   state => ({
     settings: state.settings,
   }),
-  { changeSettings },
+  {
+    changeSettings,
+    clearSettings,
+  },
 )(Settings);
 
-export default ConnectedSettings;
+export default withRouter(ConnectedSettings);

--- a/src/app/modules/crypto/reducers.ts
+++ b/src/app/modules/crypto/reducers.ts
@@ -1,4 +1,5 @@
 import types from './types';
+import settingsTypes from 'modules/settings/types';
 
 export interface CryptoState {
   salt: null | string;
@@ -70,6 +71,15 @@ export default function cryptoReducers(
         ...state,
         ...action.payload,
       };
+    
+    case settingsTypes.CLEAR_SETTINGS:
+      return {
+        ...state,
+        salt: null,
+        hasSetPassword: false,
+        password: null,
+        testCipher: null,
+      }
   }
 
   return state;

--- a/src/app/modules/node/reducers.ts
+++ b/src/app/modules/node/reducers.ts
@@ -1,5 +1,6 @@
 import LndHttpClient, { Macaroon, GetInfoResponse } from 'lib/lnd-http';
 import types from './types';
+import settingsTypes from 'modules/settings/types';
 
 export interface NodeState {
   lib: LndHttpClient | null;
@@ -111,6 +112,15 @@ export default function cryptoReducers(
 
     case types.RESET_NODE:
       return { ...INITIAL_STATE };
+    
+    case settingsTypes.CLEAR_SETTINGS:
+      return {
+        ...state,
+        lib: null,
+        url: null,
+        readonlyMacaroon: null,
+        adminMacaroon: null,
+      };
   }
 
   return state;

--- a/src/app/modules/settings/actions.ts
+++ b/src/app/modules/settings/actions.ts
@@ -5,12 +5,16 @@ export function changeSettings(changes: Partial<SettingsState>) {
   return {
     type: types.CHANGE_SETTINGS,
     payload: changes,
-  }
+  };
 }
 
 export function loadSettings(settings: Partial<SettingsState>) {
   return {
     type: types.LOAD_SETTINGS,
     payload: settings,
-  }
+  };
+}
+
+export function clearSettings() {
+  return { type: types.CLEAR_SETTINGS };
 }

--- a/src/app/modules/settings/types.ts
+++ b/src/app/modules/settings/types.ts
@@ -1,6 +1,7 @@
 enum SettingsTypes {
   CHANGE_SETTINGS = 'CHANGE_SETTINGS',
   LOAD_SETTINGS = 'LOAD_SETTINGS',
+  CLEAR_SETTINGS = 'CLEAR_SETTINGS',
 }
 
 export default SettingsTypes;

--- a/src/app/utils/crypto.ts
+++ b/src/app/utils/crypto.ts
@@ -46,8 +46,10 @@ export const syncConfigs: Array<SyncConfig<any>> = [
     encrypted: false,
     selector: selectSyncedCryptoState,
     action: setSyncedCryptoState,
-    // TODO: Add triggers for when they reset account, import account
-    triggerActions: [cryptoTypes.SET_PASSWORD],
+    triggerActions: [
+      cryptoTypes.SET_PASSWORD,
+      settingsTypes.CLEAR_SETTINGS,
+    ],
   },
   {
     key: 'node-unencrypted',
@@ -57,6 +59,7 @@ export const syncConfigs: Array<SyncConfig<any>> = [
     triggerActions: [
       nodeTypes.SET_NODE,
       nodeTypes.RESET_NODE,
+      settingsTypes.CLEAR_SETTINGS,
     ],
   },
   {
@@ -67,6 +70,7 @@ export const syncConfigs: Array<SyncConfig<any>> = [
     triggerActions: [
       nodeTypes.SET_NODE,
       nodeTypes.RESET_NODE,
+      settingsTypes.CLEAR_SETTINGS,
     ],
   },
   {


### PR DESCRIPTION
Adds a button to the settings menu that resets your node & password. In the future, we'll probably want a more elegant user swap behavior, but this'll do for now.

![capture](https://user-images.githubusercontent.com/649992/49039631-4defa080-f18e-11e8-8c48-03ba4d81faf7.PNG)
