### PR TITLE
Faster WebLN Inject

### DIFF
--- a/src/content_script/injectScript.ts
+++ b/src/content_script/injectScript.ts
@@ -3,9 +3,10 @@ import { browser } from 'webextension-polyfill-ts';
 export default function injectScript() {
   try {
     if (!document) throw new Error('No document');
-    const container = document.body;
+    const container = document.head || document.documentElement;
     if (!container) throw new Error('No container element');
     const scriptEl = document.createElement('script');
+    scriptEl.setAttribute('async', 'false');
     scriptEl.setAttribute('type', 'text/javascript');
     scriptEl.setAttribute('src', browser.extension.getURL('inpage_script.js'));
     container.appendChild(scriptEl);

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -22,7 +22,7 @@
       "https://*/*"
     ],
     "js": ["content_script.js"],
-    "run_at": "document_end",
+    "run_at": "document_start",
     "all_frames": true
   }],
   "background": {


### PR DESCRIPTION
Closes #52. Injects WebLN at `document_start` instead of `document_end`.