### PR TITLE
Fix development setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ the ability to pay and use your node as an identity on the web.
 
 ## Development
 
-1. Run `yarn start`
-2. Open Chrome -> More Tools -> Extensions -> Load Unpacked
-3. Select the `joule-extension/dist-dev` folder you created
-4. Get to work!
+1. Run `yarn install && yarn run build:dev`
+2. Open Chrome -> More Tools -> Extensions
+3. Toggle "Developer mode" (if such a toggle exists)
+4. Click "Load unpacked"
+5. Select the `joule-extension/dist-dev` folder you created
+6. Get to work!
 
 If you're also working on [`webln`](https://github.com/wbobeirne/webln), you'll
 want to clone and build that repository, and run `yarn link`. Then come back


### PR DESCRIPTION
Not sure if I'm missing something, but the development README instructions didn't work for me.

```
(1) [Fri 30 12:12] james/src/joule-extension readme (019ed1d)
 $ yarn --version
1.12.3

 (0) [Fri 30 12:12] james/src/joule-extension readme (019ed1d)
 $ yarn start --help
yarn run v1.12.3
error Command "start" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```