### PR TITLE
Implement webln.getInfo

### DIFF
--- a/src/background_script/getNodeInfo.ts
+++ b/src/background_script/getNodeInfo.ts
@@ -1,0 +1,22 @@
+import { GetInfoResponse } from 'webln/lib/provider';
+import runSelector from '../content_script/runSelector';
+import { LndHttpClient } from 'lib/lnd-http';
+import { selectSyncedUnencryptedNodeState } from 'modules/node/selectors';
+
+export default async function getNodeInfo(): Promise<GetInfoResponse> {
+  const state = await runSelector(selectSyncedUnencryptedNodeState, 'node-unencrypted', 'node');
+  if (!state.url || !state.readonlyMacaroon) {
+    throw new Error('Node has not been set up');
+  }
+
+  const client = new LndHttpClient(state.url, state.readonlyMacaroon);
+  const info = await client.getInfo();
+  const moreInfo = await client.getNodeInfo(info.identity_pubkey);
+  return {
+    node: {
+      alias: info.alias,
+      pubkey: info.identity_pubkey,
+      color: moreInfo.node.color,
+    },
+  };
+}

--- a/src/background_script/index.ts
+++ b/src/background_script/index.ts
@@ -1,6 +1,8 @@
 import qs from 'query-string';
 import { browser, Runtime } from 'webextension-polyfill-ts';
 import { OriginData } from 'utils/prompt';
+import { PROMPT_TYPE } from '../webln/types';
+import getNodeInfo from './getNodeInfo';
 
 interface PromptRequest {
   type: string;
@@ -52,6 +54,11 @@ function openPrompt(request: PromptRequest): Promise<any> {
 // Background manages communication between page and its windows
 browser.runtime.onMessage.addListener((request: any) => {
   if (request && request.application === 'Joule' && request.prompt) {
+    // Special case -- get info requires no prompt, just respond
+    if (request.type === PROMPT_TYPE.INFO) {
+      return getNodeInfo().then(data => ({ data }));
+    }
+
     // WebLNProvider request, will require window open
     return openPrompt(request)
       .then(data => {

--- a/src/content_script/runSelector.ts
+++ b/src/content_script/runSelector.ts
@@ -1,0 +1,17 @@
+import { browser } from 'webextension-polyfill-ts';
+import { AppState, combineInitialState } from 'store/reducers';
+
+type Selector<T> = (s: AppState) => T;
+
+export default async function runSelector<T>(
+  selector: Selector<T>,
+  storageKey: string,
+  stateKey: string,
+): Promise<T> {
+  const storageData = await browser.storage.sync.get(storageKey);
+  const state = {
+    ...combineInitialState,
+    ...{ [stateKey]: storageData[storageKey] },
+  } as AppState;
+  return selector(state);
+}

--- a/src/webln/provider.ts
+++ b/src/webln/provider.ts
@@ -1,5 +1,6 @@
 import {
   WebLNProvider,
+  GetInfoResponse,
   SendPaymentResponse,
   RequestInvoiceArgs,
   RequestInvoiceResponse,
@@ -23,8 +24,7 @@ export default class JouleWebLNProvider implements WebLNProvider {
     if (!this.isEnabled) {
       throw new Error('Provider must be enabled before calling getInfo');
     }
-    throw new Error('Not yet implemented');
-    return { node: { alias: '', color: '', pubkey: '' } };
+    return this.promptUser<GetInfoResponse>(PROMPT_TYPE.INFO);
   }
 
   async sendPayment(paymentRequest: string) {

--- a/src/webln/types.ts
+++ b/src/webln/types.ts
@@ -1,5 +1,6 @@
 export enum PROMPT_TYPE {
   AUTHORIZE = 'AUTHORIZE',
+  INFO = 'INFO',
   PAYMENT = 'PAYMENT',
   INVOICE = 'INVOICE',
   SIGN = 'SIGN',


### PR DESCRIPTION
### What This Does

Implements the webln.getInfo call. Surprised I actually forgot this one, but here it is. A little bit of DRY cleanup along the way.

### Steps to Test

1. Call `webln.enable()` in any context and approve it
2. Call `webln.getInfo()` in any context, confirm it returns promise that resolves with info