### PR TITLE
Fix firefox number jank

### DIFF
--- a/src/app/components/InvoiceForm/index.tsx
+++ b/src/app/components/InvoiceForm/index.tsx
@@ -107,6 +107,7 @@ class InvoiceForm extends React.Component<Props, State> {
                   onChange={this.handleChangeValue}
                   autoFocus
                   placeholder="1000"
+                  step="any"
                 />
                 <Select
                   onChange={this.handleChangeDenomination}
@@ -133,6 +134,7 @@ class InvoiceForm extends React.Component<Props, State> {
                     addonBefore={fiatSymbols[fiat]}
                     placeholder="1.00"
                     disabled={!rates}
+                    step="any"
                   />
                 </>
               )}

--- a/src/app/components/InvoiceForm/style.less
+++ b/src/app/components/InvoiceForm/style.less
@@ -22,6 +22,10 @@
         min-width: 160px;
       }
 
+      .ant-input {
+        min-width: 0;
+      }
+
       .ant-select-selection-selected-value {
         font-size: 11px;
         padding-right: 12px;

--- a/src/app/prompts/invoice.tsx
+++ b/src/app/prompts/invoice.tsx
@@ -94,11 +94,11 @@ class InvoicePrompt extends React.Component<Props, State> {
               <Input.Group size="large" compact>
                 <Input
                   size="large"
-                  type="number"
                   value={value}
                   onChange={this.handleChangeValue}
                   placeholder="Enter an amount"
                   disabled={isValueDisabled}
+                  step="any"
                   autoFocus
                 />
                 <Select


### PR DESCRIPTION
Closes #63. Fixes the step issue described by using the `step="any"` attribute. Also fixes the fields toppling on top of one another as seen in the screenshot of that issue.