### PR TITLE
Allow macaroon hex string input

### DIFF
--- a/src/app/components/SelectNode/UploadMacaroons.less
+++ b/src/app/components/SelectNode/UploadMacaroons.less
@@ -5,11 +5,18 @@
     margin-bottom: 1rem;
   }
 
+  &-toggle {
+    font-size: 0.8rem;
+    opacity: 0.8;
+    margin: 1rem 0 1rem;
+    text-align: center;
+  }
+
   &-hint {
     text-align: center;
     font-size: 0.6rem;
     opacity: 0.6;
-    margin: 1.5rem 0 1.5rem;
+    margin: 1.5rem 0 1rem;
   }
 
   .ant-upload.ant-upload-drag {
@@ -34,5 +41,9 @@
         font-size: 2rem;
       }
     }
+  }
+
+  .ant-form-item {
+    margin-bottom: 0.5rem;
   }
 }

--- a/src/app/components/SelectNode/UploadMacaroons.tsx
+++ b/src/app/components/SelectNode/UploadMacaroons.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Upload, Icon, Alert, Button } from 'antd';
+import { Upload, Icon, Alert, Button, Form, Input } from 'antd';
 import { blobToHex } from 'utils/file';
 import { LND_DIR } from 'utils/constants';
 import './UploadMacaroons.less';
@@ -12,6 +12,7 @@ interface Props {
 interface State {
   admin: string;
   readonly: string;
+  isShowingHexInputs: boolean;
   error?: string;
 }
 
@@ -19,6 +20,7 @@ export default class UploadMacaroon extends React.Component<Props, State> {
   state: State = {
     admin: '',
     readonly: '',
+    isShowingHexInputs: false,
     error: this.props.error,
   };
 
@@ -29,49 +31,80 @@ export default class UploadMacaroon extends React.Component<Props, State> {
   }
 
   render() {
-    const { error, admin, readonly } = this.state;
+    const { error, admin, readonly, isShowingHexInputs } = this.state;
     return (
-      <div className="UploadMacaroons">
+      <Form layout="vertical" className="UploadMacaroons">
         <div className="UploadMacaroons-description">
           We need to authenticate with your node using macaroons. Your admin
           macaroon will be encrypted, and payments will <em>never</em> be made
           without your explicit approval.
         </div>
-        <Upload.Dragger
-          accept=".macaroon"
-          showUploadList={false}
-          beforeUpload={
-            (file) => this.handleMacaroonUpload('admin', file)
-          }
-        >
-          <p className="ant-upload-drag-icon">
-            <Icon type={admin ? 'check-circle' : 'inbox'} />
-          </p>
-          <p className="ant-upload-text">
-            Upload <code>admin.macaroon</code>
-          </p>
-          <p className="ant-upload-hint">
-            Click or drag to upload macaroon
-          </p>
-        </Upload.Dragger>
 
-        <Upload.Dragger
-          accept=".macaroon"
-          showUploadList={false}
-          beforeUpload={
-            (file) => this.handleMacaroonUpload('readonly', file)
-          }
-        >
-          <p className="ant-upload-drag-icon">
-            <Icon type={readonly ? 'check-circle' : 'inbox'} />
-          </p>
-          <p className="ant-upload-text">
-            Upload <code>readonly.macaroon</code>
-          </p>
-          <p className="ant-upload-hint">
-            Click or drag to upload
-          </p>
-        </Upload.Dragger>
+        {isShowingHexInputs ? (
+          <>
+            <Form.Item label="Admin macaroon">
+              <Input
+                name="admin"
+                value={admin}
+                onChange={this.handleChangeMacaroonHex}
+                placeholder="Paste hex string here"
+              />
+            </Form.Item>
+            <Form.Item label="Readonly macaroon">
+              <Input
+                name="readonly"
+                value={readonly}
+                onChange={this.handleChangeMacaroonHex}
+                placeholder="Paste hex string here"
+              />
+            </Form.Item>
+          </>
+        ) : (
+          <>
+            <Upload.Dragger
+              accept=".macaroon"
+              showUploadList={false}
+              beforeUpload={
+                (file) => this.handleMacaroonUpload('admin', file)
+              }
+            >
+              <p className="ant-upload-drag-icon">
+                <Icon type={admin ? 'check-circle' : 'inbox'} />
+              </p>
+              <p className="ant-upload-text">
+                Upload <code>admin.macaroon</code>
+              </p>
+              <p className="ant-upload-hint">
+                Click or drag to upload macaroon
+              </p>
+            </Upload.Dragger>
+
+            <Upload.Dragger
+              accept=".macaroon"
+              showUploadList={false}
+              beforeUpload={
+                (file) => this.handleMacaroonUpload('readonly', file)
+              }
+            >
+              <p className="ant-upload-drag-icon">
+                <Icon type={readonly ? 'check-circle' : 'inbox'} />
+              </p>
+              <p className="ant-upload-text">
+                Upload <code>readonly.macaroon</code>
+              </p>
+              <p className="ant-upload-hint">
+                Click or drag to upload
+              </p>
+            </Upload.Dragger>
+
+            <div className="UploadMacaroons-hint">
+              Macaroons are usually located in either{' '}
+              <code>{LND_DIR.MACOS}</code> on macOS, or{' '}
+              <code>{LND_DIR.LINUX}</code> on Linux if you’re running LND.
+              Other clients may differ.
+            </div>
+          </>
+        )}
 
         {error &&
           <Alert
@@ -83,11 +116,10 @@ export default class UploadMacaroon extends React.Component<Props, State> {
           />
         }
 
-        <div className="UploadMacaroons-hint">
-          Macaroons are usually located in either{' '}
-          <code>{LND_DIR.MACOS}</code> on macOS, or{' '}
-          <code>{LND_DIR.LINUX}</code> on Linux if you’re running LND.
-          Other clients may differ.
+        <div className="UploadMacaroons-toggle">
+          {isShowingHexInputs ? 'Have macaroon files instead?' : 'Have hex strings instead?'}
+          {' '}
+          <a onClick={this.toggleHexInputs}>Click here to switch</a>.
         </div>
 
         <Button
@@ -99,7 +131,7 @@ export default class UploadMacaroon extends React.Component<Props, State> {
         >
           Continue
         </Button>
-      </div>
+      </Form>
     );
   }
 
@@ -111,6 +143,14 @@ export default class UploadMacaroon extends React.Component<Props, State> {
         .catch(err => this.setState({ error: err.message }));
     }
     return false;
+  };
+
+  private handleChangeMacaroonHex = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ [ev.target.name]: ev.target.value } as any);
+  };
+
+  private toggleHexInputs = () => {
+    this.setState({ isShowingHexInputs: !this.state.isShowingHexInputs });
   };
 
   private handleSubmit = () => {


### PR DESCRIPTION
Closes #58.

### What This Does

Allows for the input of raw hex strings for macaroons, instead of file uploads. Togglable by clicking a link towards the bottom. This probably won't be the final UX for BTCPay Server users (And any other clients that expose macaroons as a hex string,) but this makes it possible to setup in the short term.

### Steps to Test

1. Spin up a BTCPay Server
2. Navigate to `/server/services/lnd-rest/BTC/1`
3. Setup Joule using your REST API endpoint and macaroon hex string

## Screenshots

### Default view

<img width="725" alt="screen shot 2018-12-04 at 2 40 26 am" src="https://user-images.githubusercontent.com/649992/49426688-483a2200-f76f-11e8-9c65-e080ef9fa6a5.png">


### Toggled & filled out

<img width="707" alt="screen shot 2018-12-04 at 2 41 43 am" src="https://user-images.githubusercontent.com/649992/49426694-4c663f80-f76f-11e8-9efe-924f519f1cb0.png">


### Connected!

<img width="713" alt="screen shot 2018-12-04 at 2 41 48 am" src="https://user-images.githubusercontent.com/649992/49426700-4ff9c680-f76f-11e8-80d8-b8ffb344dde8.png">
