### PR TITLE
[FIX] Errorous settings state on enable

### DIFF
--- a/src/content_script/runSelector.ts
+++ b/src/content_script/runSelector.ts
@@ -6,12 +6,16 @@ type Selector<T> = (s: AppState) => T;
 export default async function runSelector<T>(
   selector: Selector<T>,
   storageKey: string,
-  stateKey: string,
+  stateKey: keyof AppState,
 ): Promise<T> {
   const storageData = await browser.storage.sync.get(storageKey);
+  const keyData = storageData[storageKey] || {};
   const state = {
     ...combineInitialState,
-    ...{ [stateKey]: storageData[storageKey] },
+    [stateKey]: {
+      ...combineInitialState[stateKey],
+      ...keyData,
+    },
   } as AppState;
   return selector(state);
 }


### PR DESCRIPTION
Fixes an issue where an empty settings state (e.g. you just installed and never changed settings) cause `webln.enable()` calls to fail. This will require a v0.2.1 release.