### PR TITLE
Fix typo

### DIFF
--- a/src/app/components/SelectNode/index.tsx
+++ b/src/app/components/SelectNode/index.tsx
@@ -113,9 +113,8 @@ class SelectNode extends React.Component<Props, State> {
           <Collapse>
             <Collapse.Panel header="Need help? Click here" key="help">
               <p>
-                In order to run Joule, you must run your own LND node (Other
-                node types coming soon.) You have a few options fow how you can
-                do that:
+                In order to run Joule, you must run your own LND node (other
+                node types coming soon). You can use one of the following for example:
               </p>
               <ul>
                 <li>


### PR DESCRIPTION
- Typo in "You have a few options **fow** how you can do that"
- Wrong location for the full stop in "[...] soon.) You [...]"
- Add "for example" in order for the sentence to be correct even when there will be more options in the future