### PR TITLE
Channel progress bars

### DIFF
--- a/src/app/components/ChannelList/ChannelRow.less
+++ b/src/app/components/ChannelList/ChannelRow.less
@@ -39,5 +39,20 @@
       font-size: 0.7rem;
       opacity: 0.8;
     }
+
+    &-progress-bar-background {
+      width: 100%;
+      height: 5px;
+      background-color: #f1f1f1!important;
+      border-radius: 4px;
+      opacity: 0.9;
+      margin-top: 2px;
+    }
+  
+  &-progress-bar {
+      height: 5px;
+      background-color: @primary-color !important;
+      border-radius: 4px;
   }
+}
 }

--- a/src/app/components/ChannelList/ChannelRow.tsx
+++ b/src/app/components/ChannelList/ChannelRow.tsx
@@ -34,6 +34,9 @@ export default class ChannelRow extends React.Component<Props> {
             {' / '}
             <Unit value={channel.capacity} />
           </div>
+          <div className="ChannelRow-info-progress-bar-background">
+            <div className="ChannelRow-info-progress-bar" style={{width: Math.round(parseFloat(channel.local_balance) / parseFloat(channel.capacity) * 100) + '%'}}></div>
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
This pull request adds channel progress bars to the channel overview.

Let me know what you think, I can make changes to the style if needed. This also adds Bootstrap to the Project so if this is not wanted, I can try to accomplish the task in a different way.

There is still one bug in this which I don't understand:
When the plugin is clicked the Channel Balance does not display, only if you maximize the window or e.g. click on settings and then it shows up. If someone knows how to fix it I would be grateful.