### PR TITLE
Ask for permissions as needed

### DIFF
--- a/src/app/components/SelectNode/InputAddress.tsx
+++ b/src/app/components/SelectNode/InputAddress.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Form, Input, Button, Alert } from 'antd';
+import { browser } from 'webextension-polyfill-ts';
+import { Form, Input, Button, Alert, message } from 'antd';
 import './InputAddress.less';
 
 interface Props {
@@ -93,7 +94,15 @@ export default class InputAddress extends React.Component<Props, State> {
 
   private handleSubmit = (ev: React.FormEvent<HTMLFormElement>) => {
     ev.preventDefault();
-    this.props.submitUrl(this.state.url);
-    this.setState({ submittedUrl: this.state.url });
+    const url = new URL(this.state.url);
+    browser.permissions.request({
+      origins: [`${url.origin}/`]
+    }).then(accepted => {
+      if (!accepted) {
+        message.warn('Permission denied, connection may fail');
+      }
+      this.props.submitUrl(this.state.url);
+      this.setState({ submittedUrl: this.state.url });
+    });
   };
 }

--- a/src/app/components/SelectNode/index.tsx
+++ b/src/app/components/SelectNode/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Button, Spin, Collapse } from 'antd';
+import { Button, Spin, Collapse, message } from 'antd';
+import { browser } from 'webextension-polyfill-ts';
 import UploadMacaroons from './UploadMacaroons';
 import ConfirmNode from './ConfirmNode';
 import { DEFAULT_LOCAL_NODE_URL } from 'utils/constants';
@@ -176,8 +177,15 @@ class SelectNode extends React.Component<Props, State> {
     this.setState({ nodeType });
     if (nodeType === NODE_TYPE.LOCAL) {
       // Instantly check the default local node
-      this.setState({ url: DEFAULT_LOCAL_NODE_URL });
-      this.props.checkNode(DEFAULT_LOCAL_NODE_URL);
+      browser.permissions.request({
+        origins: [`${DEFAULT_LOCAL_NODE_URL}/`]
+      }).then(accepted => {
+        if (!accepted) {
+          message.warn('Permission denied, connection may fail');
+        }
+        this.setState({ url: DEFAULT_LOCAL_NODE_URL });
+        this.props.checkNode(DEFAULT_LOCAL_NODE_URL);
+      });
     }
   };
 

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -36,13 +36,13 @@
   ],
   "permissions": [
     "storage",
+    "clipboardWrite",
     "activeTab"
   ],
   "optional_permissions": [
     "notifications",
     "http://*/",
-    "https://*/",
-    "file://*/"
+    "https://*/"
   ],
   "applications": {
     "gecko": {

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -36,11 +36,13 @@
   ],
   "permissions": [
     "storage",
+    "activeTab"
+  ],
+  "optional_permissions": [
     "notifications",
-    "webRequest",
     "http://*/",
     "https://*/",
-    "file://*/*"
+    "file://*/"
   ],
   "applications": {
     "gecko": {


### PR DESCRIPTION
In the short term, this closes #12, though it can be improved further in the future.

### What This Does

* Removes the cart-blanche domain permission.
* Asks for permission to the domain you try to connect your node to.
* Adds `clipboardWrite` and `activeTab` as permissions asked for.

## Screenshots

### Request access to domain

<img width="1265" alt="screen shot 2018-12-11 at 8 15 59 pm" src="https://user-images.githubusercontent.com/649992/49840615-2863b900-fd82-11e8-83f5-06484a45ae82.png">

### activeTab permission when all access is revoked

<img width="339" alt="screen shot 2018-12-11 at 8 20 50 pm" src="https://user-images.githubusercontent.com/649992/49840654-59dc8480-fd82-11e8-9324-c0d329f262b8.png">
