### PR TITLE
BTCPay Server onboarding

### DIFF
--- a/src/app/components/SelectNode/BTCPayServer.less
+++ b/src/app/components/SelectNode/BTCPayServer.less
@@ -1,0 +1,24 @@
+.BTCPayServer {
+  width: 100%;
+  max-width: 500px;
+  margin: 0 auto;
+
+  &-steps {
+    font-size: 0.85rem;
+    opacity: 0.8;
+
+    > li {
+      margin-bottom: 0.1rem;
+    }
+  }
+
+  &-form {
+    .ant-form-item {
+      margin-bottom: 0;
+
+      &.ant-form-item-with-help {
+        margin-bottom: 0.25rem;
+      }
+    }
+  }
+}

--- a/src/app/components/SelectNode/BTCPayServer.less
+++ b/src/app/components/SelectNode/BTCPayServer.less
@@ -21,4 +21,11 @@
       }
     }
   }
+
+  &-help {
+    text-align: center;
+    margin-top: 1.25rem;
+    font-size: 0.7rem;
+    opacity: 0.5;
+  }
 }

--- a/src/app/components/SelectNode/BTCPayServer.tsx
+++ b/src/app/components/SelectNode/BTCPayServer.tsx
@@ -41,7 +41,7 @@ export default class BTCPayServer extends React.Component<Props, State> {
 
     return (
       <div className="BTCPayServer">
-        <p className="BTCPayServer-help">
+        <p>
           Follow these steps to connect your BTCPay Server to Joule. Your node
           must be fully synced in order to get connection details.
         </p>
@@ -76,6 +76,17 @@ export default class BTCPayServer extends React.Component<Props, State> {
             Submit
           </Button>
         </Form>
+        <div className="BTCPayServer-help">
+          Want to learn more about BTCPay Server?
+          {' '}
+          <a
+            href="https://github.com/btcpayserver/btcpayserver"
+            target="_blank"
+            rel="noopener nofollow"
+          >
+            Click here
+          </a>.
+        </div>
       </div>
     );
   }

--- a/src/app/components/SelectNode/BTCPayServer.tsx
+++ b/src/app/components/SelectNode/BTCPayServer.tsx
@@ -9,7 +9,7 @@ export interface BTCPayServerConfig {
   cryptoCode: string;
   uri: string;
   macaroon: string;
-  restrictedMacaroon?: string;
+  readonlyMacaroon?: string;
 }
 
 interface Props {

--- a/src/app/components/SelectNode/BTCPayServer.tsx
+++ b/src/app/components/SelectNode/BTCPayServer.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { browser } from 'webextension-polyfill-ts';
+import { Form, Input, Button, message } from 'antd';
+import './BTCPayServer.less';
+
+export interface BTCPayServerConfig {
+  chainType: string;
+  type: string;
+  cryptoCode: string;
+  uri: string;
+  macaroon: string;
+  restrictedMacaroon?: string;
+}
+
+interface Props {
+  error?: Error | null;
+  submitConfig(config: BTCPayServerConfig): void;
+}
+
+interface State {
+  configData: string;
+  isSubmitting: boolean;
+}
+
+export default class BTCPayServer extends React.Component<Props, State> {
+  state: State = {
+    configData: '',
+    isSubmitting: false,
+  };
+
+  componentWillUpdate(nextProps: Props) {
+    if (nextProps.error && this.props.error !== nextProps.error) {
+      message.error(nextProps.error.message);
+    }
+  }
+
+  render() {
+    const { configData, isSubmitting } = this.state;
+    const url = this.getConfigDataUrl(configData);
+    const error = configData && !url ? 'Invalid config data' : undefined;
+
+    return (
+      <div className="BTCPayServer">
+        <p className="BTCPayServer-help">
+          Follow these steps to connect your BTCPay Server to Joule. Your node
+          must be fully synced in order to get connection details.
+        </p>
+        <ol className="BTCPayServer-steps">
+          <li>Navigate to your BTCPayServer and log in as an admin</li>
+          <li>Go to Server Settings > Services > LND Rest - See information</li>
+          <li>Click "See QR Code information" and copy the QR Code data</li>
+          <li>Paste the data below:</li>
+        </ol>
+        <Form className="BTCPayServer-form" onSubmit={this.handleSubmit} layout="vertical">
+          <Form.Item
+            label="Connect data"
+            help={error}
+            validateStatus={error ? 'error' : url ? 'success' : undefined}
+          >
+            <Input
+              size="large"
+              value={configData}
+              onChange={this.handleChange}
+              placeholder="config=https://yourserver.lndyn.com/lndconfig/12345/lnd.config"
+              autoFocus
+            />
+          </Form.Item>
+          <Button
+            type="primary"
+            htmlType="submit"
+            size="large"
+            disabled={!url}
+            loading={isSubmitting}
+            block
+          >
+            Submit
+          </Button>
+        </Form>
+      </div>
+    );
+  }
+
+  private getConfigDataUrl(data: string) {
+    const url = data.replace('config=', '');
+    try {
+      return new URL(url);
+    } catch (err) {
+      return false;
+    }
+  }
+
+  private handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ configData: ev.currentTarget.value });
+  };
+
+  private handleSubmit = async (ev: React.FormEvent<HTMLFormElement>) => {
+    ev.preventDefault();
+    const url = this.getConfigDataUrl(this.state.configData);
+    this.setState({ isSubmitting: true });
+
+    if (url) {
+      try {
+        const accepted = await browser.permissions.request({ origins: [`${url.origin}/`] });
+        if (!accepted) {
+          message.warn('Permission denied, connection may fail', 2);
+        }
+        const response = await fetch(url.href);
+        const json = await response.json();
+        const lndConfig = json.configurations.find((conf: BTCPayServerConfig) => {
+          return conf.type === 'lnd-rest';
+        });
+
+        if (!lndConfig) {
+          console.error('No LND configuration found in configurations:', json);
+          message.error('No LND configuration found', 2);
+        }
+        this.props.submitConfig(lndConfig);
+      } catch(err) {
+        console.error(err);
+        message.error('Failed to connect to BTCPay Server', 2);
+      }
+    } else {
+      message.error('Invalid config data', 2);
+    }
+
+    this.setState({ isSubmitting: false });
+  };
+}

--- a/src/app/components/SelectNode/SelectType.tsx
+++ b/src/app/components/SelectNode/SelectType.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Button, Collapse } from 'antd';
+import { Button, Collapse, Icon } from 'antd';
+import BTCPayServerIcon from 'static/images/btcpayserver.svg';
 import './SelectType.less';
 
 export enum NODE_TYPE {
   LOCAL = 'LOCAL',
   REMOTE = 'REMOTE',
+  BTCPAY_SERVER = 'BTCPAY_SERVER',
 }
 
 interface Props {
@@ -32,6 +34,13 @@ export default class SelectType extends React.Component<Props> {
           onClick={() => onSelectNodeType(NODE_TYPE.REMOTE)}
         >
           Remote node
+        </Button>
+        <Button
+          size="large"
+          block
+          onClick={() => onSelectNodeType(NODE_TYPE.BTCPAY_SERVER)}
+        >
+          <Icon component={BTCPayServerIcon} /> BTCPay Server
         </Button>
         <Collapse>
           <Collapse.Panel header="Need help? Click here" key="help">

--- a/src/app/components/SelectNode/index.tsx
+++ b/src/app/components/SelectNode/index.tsx
@@ -163,7 +163,7 @@ class SelectNode extends React.Component<Props, State> {
   private handleBTCPayServerConfig = (config: BTCPayServerConfig) => {
     const macaroons = {
       adminMacaroon: config.macaroon,
-      readonlyMacaroon: config.restrictedMacaroon || config.macaroon,
+      readonlyMacaroon: config.readonlyMacaroon || config.macaroon,
     };
     this.setState(macaroons, () => {
       this.props.checkAuth(

--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -5,7 +5,7 @@ import * as T from './types';
 export * from './errors';
 export * from './types';
 
-type ApiMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+export type ApiMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 export class LndHttpClient {
   url: string;
@@ -217,9 +217,10 @@ export class LndHttpClient {
   };
 
   // Internal fetch function
-  private request<R extends object, A extends object | undefined = undefined>(
+  protected request<R extends object, A extends object | undefined = undefined>(
     method: ApiMethod,
-    path: string, args?: A,
+    path: string,
+    args?: A,
     defaultValues?: Partial<R>,
   ): T.Response<R> {
     let body = null;

--- a/src/app/static/images/btcpayserver.svg
+++ b/src/app/static/images/btcpayserver.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 59 105" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M6.5,6.5 L51.5,29.5" id="Line-2" stroke="#CEDE00" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"></path>
+        <path d="M51.5,29.5 L21.5,52.5" id="Line-3" stroke="#CEDE00" stroke-width="12" stroke-linecap="round"></path>
+        <path d="M52.4755859,76.7333984 L19.3574219,52.9433594" id="Path-3" stroke="#4DB335" stroke-width="12" stroke-linecap="round"></path>
+        <polygon id="Path-2" fill="#177B42" points="30.2770996 53.3812256 9.22851562 69.3564453 9.22851562 36.8125"></polygon>
+        <path d="M6.5,98.5 L6.5,7.5" id="Line" stroke="#CEDE00" stroke-width="12" stroke-linecap="round"></path>
+        <path d="M52,77 L6.5,98.5" id="Line-4" stroke="#4DB335" stroke-width="12" stroke-linecap="round"></path>
+    </g>
+</svg>

--- a/src/app/utils/background.ts
+++ b/src/app/utils/background.ts
@@ -1,0 +1,24 @@
+import { LndHttpClient, ApiMethod } from 'lib/lnd-http';
+import * as T from 'lib/lnd-http/types';
+
+// An API-compatible proxy to the background script that does the actual
+// request using credentials stored in memory.
+export class BackgroundProxy extends LndHttpClient {
+  constructor() {
+    // Send in blank info, it'll go unused
+    super('', '');
+  }
+
+  // Override the request method that all other methods use
+  protected request<R extends object, A extends object | undefined = undefined>(
+    method: ApiMethod,
+    path: string,
+    args?: A,
+    defaultValues?: Partial<R>,
+  ): T.Response<R> {
+    console.log(method, path, args, defaultValues);
+    return Promise.reject(Error('Sup'));
+  }
+}
+
+export const backgroundProxy = new BackgroundProxy();


### PR DESCRIPTION
<!-- New to the project? Check out the Contributor Guidelines! -->
<!-- https://github.com/wbobeirne/joule-extension/wiki/Contributor-Guidelines -->

Closes #79. Will want a review from @NicolasDorier on this one.

### Description

Adds an option to the node selector for BTCPay Server. Uses the BTCPay Server config format for filling out URI & macaroons.

### Steps to Test

1. Setup a BTCPay Server
2. Go through Joule onboarding, select BTCPay Server
3. Follow the instructions and fill out the config data
4. Confirm you connect correctly

### Screenshots

![onboarding](https://user-images.githubusercontent.com/649992/50046775-01a1cd00-0077-11e9-8ac5-13d3f756178c.png)

^Click to embiggen