### PR TITLE
Onboarding prompt

### DIFF
--- a/src/app/PromptRoutes.tsx
+++ b/src/app/PromptRoutes.tsx
@@ -1,16 +1,32 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { Switch, Route, withRouter, RouteComponentProps } from 'react-router';
 import Loader from 'components/Loader';
+import OnboardingPrompt from 'prompts/onboarding';
 import AuthorizePrompt from 'prompts/authorize';
 import PaymentPrompt from 'prompts/payment';
 import InvoicePrompt from 'prompts/invoice';
 import SignPrompt from 'prompts/sign';
 import VerifyPrompt from 'prompts/verify';
 import { getPromptType } from 'utils/prompt';
+import { AppState } from 'store/reducers';
 
+interface StateProps {
+  hasSetPassword: AppState['crypto']['hasSetPassword'];
+}
 
-class Routes extends React.Component<RouteComponentProps> {
+type Props = StateProps & RouteComponentProps;
+
+class Routes extends React.Component<Props> {
   componentWillMount() {
+    const { hasSetPassword, history, location } = this.props;
+    if (!hasSetPassword) {
+      if (location.pathname !== '/onboarding') {
+        history.replace('/onboarding');
+        return;
+      }
+    }
+
     const type = getPromptType();
     this.props.history.replace(`/${type}`);
   }
@@ -19,6 +35,7 @@ class Routes extends React.Component<RouteComponentProps> {
     return (
       <Switch>
         <Route path="/" exact render={() => <Loader />} />
+        <Route path="/onboarding" exact component={OnboardingPrompt} />
         <Route path="/authorize" exact component={AuthorizePrompt} />
         <Route path="/payment" exact component={PaymentPrompt} />
         <Route path="/invoice" exact component={InvoicePrompt} />
@@ -30,4 +47,10 @@ class Routes extends React.Component<RouteComponentProps> {
   }
 }
 
-export default withRouter(Routes);
+const ConnectedRoutes = connect<StateProps, {}, {}, AppState>(
+  state => ({
+    hasSetPassword: state.crypto.hasSetPassword,
+  }),
+)(Routes);
+
+export default withRouter(ConnectedRoutes);

--- a/src/app/components/PromptTemplate/index.tsx
+++ b/src/app/components/PromptTemplate/index.tsx
@@ -8,6 +8,7 @@ interface Props {
   children: React.ReactNode;
   isContentCentered?: boolean;
   isConfirmDisabled?: boolean;
+  hasNoButtons?: boolean;
   beforeReject?(): any;
   beforeConfirm?(): any;
   getConfirmData?(): any;
@@ -25,7 +26,7 @@ export default class PromptTemplate extends React.Component<Props, State> {
   };
 
   render() {
-    const { children, isConfirmDisabled, isContentCentered } = this.props;
+    const { children, isConfirmDisabled, isContentCentered, hasNoButtons } = this.props;
     const { isConfirming, isRejecting } = this.state;
     const confirmDisabled = isConfirmDisabled || isRejecting;
 
@@ -34,23 +35,25 @@ export default class PromptTemplate extends React.Component<Props, State> {
         <div className={classnames('PromptTemplate-content', isContentCentered && 'is-centered')}>
           {children}
         </div>
-        <div className="PromptTemplate-buttons">
-          <Button
-            onClick={this.handleReject}
-            disabled={isConfirming}
-            loading={isRejecting}
-          >
-            Reject
-          </Button>
-          <Button
-            type="primary"
-            onClick={this.handleConfirm}
-            disabled={confirmDisabled}
-            loading={isConfirming}
-          >
-            Confirm
-          </Button>
-        </div>
+        {!hasNoButtons &&
+          <div className="PromptTemplate-buttons">
+            <Button
+              onClick={this.handleReject}
+              disabled={isConfirming}
+              loading={isRejecting}
+            >
+              Reject
+            </Button>
+            <Button
+              type="primary"
+              onClick={this.handleConfirm}
+              disabled={confirmDisabled}
+              loading={isConfirming}
+            >
+              Confirm
+            </Button>
+          </div>
+        }
       </div>
     )
   }

--- a/src/app/prompts/onboarding.less
+++ b/src/app/prompts/onboarding.less
@@ -41,4 +41,18 @@
     margin-bottom: 1.5rem;
     font-size: 0.9rem;
   }
+
+  &-cancel {
+    display: block;
+    text-align: center;
+    padding: 0.5rem 0 0;
+    opacity: 0.4;
+    font-size: 0.8rem;
+    color: inherit;
+    transition: opacity 70ms ease;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
 }

--- a/src/app/prompts/onboarding.less
+++ b/src/app/prompts/onboarding.less
@@ -1,0 +1,44 @@
+.OnboardingPrompt {
+  margin: 1.25rem;
+  padding: 0.75rem 1rem 1rem;
+  background: #FFF;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(#000, 0.2);
+  font-size: 0.9rem;
+
+  &-graphic {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 0.75rem;
+
+    &-icon {
+      width: 3.8rem;
+      height: 3.8rem;
+      padding: 0.5rem;
+
+      img {
+        width: 100%;
+        height: 100%;
+      }
+    }
+
+    &-divider {
+      padding: 0 1rem;
+      font-size: 1.4rem;
+      opacity: 0.4;
+    }
+  }
+
+  &-title {
+    text-align: center;
+    font-size: 1.3rem;
+    margin-bottom: 1.5rem;
+  }
+
+  &-text {
+    text-align: center;
+    margin-bottom: 1.5rem;
+    font-size: 0.9rem;
+  }
+}

--- a/src/app/prompts/onboarding.tsx
+++ b/src/app/prompts/onboarding.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Icon, Button } from 'antd';
+import { browser } from 'webextension-polyfill-ts';
+import { getPromptOrigin, OriginData } from 'utils/prompt';
+import Logo from 'static/images/logo.png';
+import PromptTemplate from 'components/PromptTemplate';
+import './onboarding.less';
+
+export default class OnboardingPrompt extends React.Component {
+  private origin: OriginData;
+
+  constructor(props: {}) {
+    super(props);
+    this.origin = getPromptOrigin();
+  }
+
+  render() {
+    return (
+      <PromptTemplate hasNoButtons isContentCentered>
+        <div className="OnboardingPrompt">
+          <div className="OnboardingPrompt-graphic">
+            <div className="OnboardingPrompt-graphic-icon">
+              <img src={this.origin.icon || ''} />
+            </div>
+            <div className="OnboardingPrompt-graphic-divider">
+              <Icon type="swap" />
+            </div>
+            <div className="OnboardingPrompt-graphic-icon">
+              <img src={Logo} />
+            </div>
+          </div>
+          <h2 className="OnboardingPrompt-title">
+            <strong>{this.origin.name}</strong>
+            {' '}
+            wants to connect
+          </h2>
+          <p className="OnboardingPrompt-text">
+            But you haven't set your node up yet! Click below to begin
+            setting up Joule with your Lightning node.
+          </p>
+          <Button
+            type="primary"
+            size="large"
+            block
+            onClick={this.startOnboarding}
+          >
+            Get started
+          </Button>
+        </div>
+      </PromptTemplate>
+    );
+  }
+
+  private startOnboarding = () => {
+    browser.runtime.openOptionsPage();
+    window.close();
+  };
+}

--- a/src/app/prompts/onboarding.tsx
+++ b/src/app/prompts/onboarding.tsx
@@ -46,6 +46,9 @@ export default class OnboardingPrompt extends React.Component {
           >
             Get started
           </Button>
+          <a className="OnboardingPrompt-cancel" onClick={this.cancel}>
+            Set up Joule later
+          </a>
         </div>
       </PromptTemplate>
     );
@@ -53,6 +56,10 @@ export default class OnboardingPrompt extends React.Component {
 
   private startOnboarding = () => {
     browser.runtime.openOptionsPage();
+    window.close();
+  };
+
+  private cancel = () => {
     window.close();
   };
 }

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -56,6 +56,7 @@ if (document) {
           application: 'Joule',
           prompt: true,
           type: PROMPT_TYPE.PAYMENT,
+          origin: getOriginData(),
           args: { paymentRequest },
         });
         ev.preventDefault();


### PR DESCRIPTION
Closes #6, sorta.

### Description

Rather than not inject WebLN if you don't have Joule configured, this changes it so that you get a prompt to onboard each time instead. This provides the user with better feedback than the current error message behavior.

### Steps to Test

1. Clear node connection settings
2. Go to a WebLN enabled website, or click on a BOLT-11 link
3. Confirm you get an onboarding prompt
4. Click and complete the onboarding
5. Either refresh the page, or click the BOLT-11 link again. Confirm it works as normal.

### Screenshots

<img width="512" alt="screen shot 2018-12-15 at 3 22 36 pm" src="https://user-images.githubusercontent.com/649992/50047193-d7540d80-007e-11e9-8887-892438ef7566.png">
