### PR TITLE
Firefox CORS warning

### DIFF
--- a/src/app/components/SelectNode/InputAddress.tsx
+++ b/src/app/components/SelectNode/InputAddress.tsx
@@ -26,6 +26,7 @@ export default class InputAddress extends React.Component<Props, State> {
     const { error, isCheckingNode } = this.props;
     const { validation, url, submittedUrl } = this.state;
     const validateStatus = url ? validation ? 'error' : 'success' : undefined;
+    const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
     const help = (url && validation) || (
       <>
         You must provide the REST API address. Must begin with{' '}
@@ -46,6 +47,26 @@ export default class InputAddress extends React.Component<Props, State> {
           />
         </Form.Item>
 
+        {error && isFirefox &&
+          <Alert
+            type="warning"
+            message="Attention Firefox user"
+            description={<>
+              <p>
+                Firefox has an issue where addons cannot bypass cross-origin
+                request prevention. If you are running lnd or the Lightning App,
+                you will be unable to connect to your node.
+              </p>
+              <p>
+                You will either have to setup a proxy server for your node, or
+                you will have to use another supported browser such as Chrome
+                or Opera.
+              </p>
+            </>}
+            showIcon
+            closable
+          />
+        }
         {error &&
           <Alert
             type="error"

--- a/src/app/components/SelectNode/InputAddress.tsx
+++ b/src/app/components/SelectNode/InputAddress.tsx
@@ -58,9 +58,9 @@ export default class InputAddress extends React.Component<Props, State> {
                 you will be unable to connect to your node.
               </p>
               <p>
-                You will either have to setup a proxy server for your node, or
-                you will have to use another supported browser such as Chrome
-                or Opera.
+                You will either have to setup a proxy server for your node that
+                has CORS headers configured, or you will have to use another
+                supported browser such as Chrome or Opera.
               </p>
             </>}
             showIcon


### PR DESCRIPTION
Triage for #99, but not a fix.

### Description

Adds a warning when you have a failed connection on Firefox that explains the current CORS issue described in #99. This will hopefully be removed as soon as either Firefox or LND addresses this issue, or I find a good work-around.

### Steps to Test

1. Run through onboarding in Firefox
2. Select "local node" as your node type
3. Confirm you see the warning if you see the error message

### Screenshots

<img width="400" alt="screen shot 2018-12-18 at 11 26 48 pm" src="https://user-images.githubusercontent.com/649992/50199136-3931a300-031d-11e9-9fa8-03430b8e0cba.png">
