### PR TITLE
Add context menu item for selected bolt11 payment requests

### DIFF
--- a/src/app/utils/validators.ts
+++ b/src/app/utils/validators.ts
@@ -3,3 +3,25 @@ import { validateMnemonic } from 'bip39';
 export function isValidMnemonic(mnemonic: string) {
   return validateMnemonic(mnemonic);
 }
+
+export function isValidPaymentReq(paymentReq: string) {
+  // must start with 'ln'
+  if (!paymentReq.startsWith('ln')) return false;
+
+  // Currency prefixes came from 
+  // https://github.com/satoshilabs/slips/blob/master/slip-0173.md
+  const prefixes = [
+    'bc',   // Bitcoin Mainnet
+    'tb',   // Bitcoin Testnet
+    'bcrt', // Bitcoin Regtest
+    'sb',   // Bitcoin Simnet
+    'ltc',  // Litecoin Mainnet
+    'tltc', // Litecoin Testnet
+    'rltc', // Litecoin Regtest
+  ]
+
+  // skip 'ln and grab the next 4 chars to match
+  const chain = paymentReq.substring(2, 6);
+  // check if the invoice starts with one of the prefixes
+  return prefixes.some(p => chain.substring(0, p.length) === p);
+}

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -63,4 +63,21 @@ if (document) {
       }
     });
   });
+
+  // Listen for right-click events to show the context menu item
+  // when a potential lightning invoice is selected
+  document.addEventListener("mousedown", (event) => {
+    // 2 = right mouse button. may be better to store in a constant
+    if (event.button == 2) {
+      const selection = window.getSelection().toString();
+      if (selection) {
+        browser.runtime.sendMessage({
+          application: 'Joule',
+          prompt: false,
+          type: PROMPT_TYPE.CONTEXT_MENU,
+          args: { selection },
+        });
+      }
+    }
+  }, true);
 }

--- a/src/webln/types.ts
+++ b/src/webln/types.ts
@@ -5,4 +5,5 @@ export enum PROMPT_TYPE {
   INVOICE = 'INVOICE',
   SIGN = 'SIGN',
   VERIFY = 'VERIFY',
+  CONTEXT_MENU = 'CONTEXT_MENU',
 };

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -37,7 +37,8 @@
   "permissions": [
     "storage",
     "clipboardWrite",
-    "activeTab"
+    "activeTab",
+    "contextMenus"
   ],
   "optional_permissions": [
     "notifications",


### PR DESCRIPTION
Closes #9 

### Description

Added a context menu item  to "Pay Lightning Invoice" when a BOLT-11 payment request string is highlighted on the page and right-clicked. When this menu item is clicked, the payment popup is displayed allowing you to confirm the payment.

### Steps to Test

1. Visit a website that accepts lightning payments 
2. Click Buy button in order to be presented with a Lightning payment request string
3. Highlight the string then right-click
4. Click on the `Pay Lightning Invoice` menu item
5. Click `Confirm` in the popup to send the bitcoin

### Screenshots

![joule_context_menu](https://user-images.githubusercontent.com/1356600/50378064-35d93880-05f7-11e9-8865-98b3ca93f334.gif)
