### PR TITLE
Firefox: fix missing icon in the toolbar

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -9,6 +9,10 @@
     "128": "icon128.png"
   },
   "browser_action": {
+    "default_icon": {
+      "16": "icon16.png",
+      "48": "icon48.png"
+    },
     "default_popup": "popup.html"
   },
   "options_ui": {


### PR DESCRIPTION
### Description

This fix repairs the missing icon in the toolbar

Relevant documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action

### Screenshots

![screenshot from 2018-12-23 02-34-58](https://user-images.githubusercontent.com/42201/50380024-8b473100-065b-11e9-881e-c975aba35017.png)

