### PR TITLE
Add support for React Dev Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ to the joule folder and run `yarn link webln`.
 
 NOTE: After making changes, you'll need to close and re-open the extension to load the latest build.
 
+Redux DevTools:
+1. Open the extension popup or full page
+2. Right click on the background
+3. Choose Redux Devtools -> Open Remote DevTools
+4. A new window will open displaying the Redux actions list
+
+React DevTools:
+1. Run `npm install -g react-devtools`
+2. Be sure to use `yarn run dev` to build the app
+2. Run `react-devtools` in a new Terminal
+3. A new window will open displaying the React vdom inspector
+
 ## Building
 
 To make a production build, follow these steps

--- a/src/options/template.html
+++ b/src/options/template.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Joule Extension</title>
+    <%= htmlWebpackPlugin.options.reactDevToolsUrl ? `<script src="${htmlWebpackPlugin.options.reactDevToolsUrl}"></script>` : '' %>
   </head>
 
   <body class="is-page">

--- a/src/popup/template.html
+++ b/src/popup/template.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Joule Extension</title>
+    <%= htmlWebpackPlugin.options.reactDevToolsUrl ? `<script src="${htmlWebpackPlugin.options.reactDevToolsUrl}"></script>` : '' %>
   </head>
 
   <body class="is-popup">

--- a/src/prompt/template.html
+++ b/src/prompt/template.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Joule Extension</title>
+    <%= htmlWebpackPlugin.options.reactDevToolsUrl ? `<script src="${htmlWebpackPlugin.options.reactDevToolsUrl}"></script>` : '' %>
   </head>
 
   <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,9 @@ const autoprefixer = require('autoprefixer');
 
 const isDev = process.env.NODE_ENV !== 'production';
 
+// url for standalone react-devtools inspector
+const reactDevToolsUrl = isDev ? 'http://localhost:8097' : '';
+
 const src = path.join(__dirname, 'src');
 const srcApp = path.join(src, 'app');
 
@@ -154,20 +157,33 @@ module.exports = {
       chunks: ['options'],
       filename: 'options.html',
       inject: true,
+      reactDevToolsUrl,
     }),
     new HtmlWebpackPlugin({
       template: `${src}/popup/template.html`,
       chunks: ['popup'],
       filename: 'popup.html',
       inject: true,
+      reactDevToolsUrl,
     }),
     new HtmlWebpackPlugin({
       template: `${src}/prompt/template.html`,
       chunks: ['prompt'],
       filename: 'prompt.html',
       inject: true,
+      reactDevToolsUrl,
     }),
     new CopyWebpackPlugin([{ from: 'static/*', flatten: true }]),
+    isDev && new CopyWebpackPlugin([{
+      from: 'static/manifest.json',
+      force: true,
+      transform: (content) => {
+        return JSON.stringify({
+          ...JSON.parse(content),
+          content_security_policy: `script-src 'self' ${reactDevToolsUrl};`
+        }, null, 2);
+      }
+    }]),
     !isDev && new ZipPlugin({
       filename: `joule-v${packageJson.version}.zip`,
     }),


### PR DESCRIPTION
Closes #114 

### Description

Adds the ability for developers to use the standalone React Dev Tools to inspect the virtual dom of each of the extension pages.

### Steps to Test

1. Run `npm install -g react-devtools`
2. Be sure to use `yarn run dev` to build the app
2. Run `react-devtools` in a new Terminal
3. A new window will open displaying the React vdom inspector 

### Screenshots

![image](https://user-images.githubusercontent.com/1356600/50501402-e7c49a80-0a25-11e9-87f5-4e7d13f7f203.png)
