### PR TITLE
Any amount invoice creation & payments

### DIFF
--- a/src/app/components/InvoiceForm/index.tsx
+++ b/src/app/components/InvoiceForm/index.tsx
@@ -146,7 +146,7 @@ class InvoiceForm extends React.Component<Props, State> {
             </div>
             <div className="InvoiceForm-form-anyValue">
               <Checkbox onChange={this.handleChangeAnyValue} checked={isAnyValue}>
-                Allow any value to be sent
+                Allow any amount to be sent
               </Checkbox>
             </div>
           </Form.Item>

--- a/src/app/components/InvoiceForm/style.less
+++ b/src/app/components/InvoiceForm/style.less
@@ -42,6 +42,12 @@
         margin-top: -5px;
       }
     }
+
+    &-anyValue {
+      margin-top: 0.25rem;
+      transform: scale(0.8);
+      transform-origin: left center;
+    }
   }
 
   &-invoice {

--- a/src/app/components/Loader.tsx
+++ b/src/app/components/Loader.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import { Icon } from 'antd';
 
-const Loader: React.SFC = () => (
+interface Props {
+  inline?: boolean;
+  size?: string;
+}
+
+const Loader: React.SFC<Props> = ({ inline, size }) => (
   <Icon
     type="loading"
     theme="outlined"
     style={{
-      position: 'absolute',
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
       color: '#8E44AD',
-      fontSize: '2rem',
+      fontSize: size || '2rem',
+      position: inline ? undefined : 'absolute',
+      top: inline ? undefined : '50%',
+      left: inline ? undefined : '50%',
+      transform: inline ? undefined : 'translate(-50%, -50%)',
     }}
   />
 );

--- a/src/app/components/SendForm/LightningSend.less
+++ b/src/app/components/SendForm/LightningSend.less
@@ -52,6 +52,20 @@
       }
     }
 
+    &-value {
+      padding: 0 1rem;
+      margin-bottom: 0.5rem;
+
+      // Ant overrides
+      .ant-input-group.ant-input-group-compact {
+        display: flex;
+      }
+
+      .ant-select-selection-selected-value {
+        font-size: 0.85rem;
+      }
+    }
+
     &-details {
       display: flex;
       flex-direction: column;

--- a/src/app/components/TransactionInfo/index.tsx
+++ b/src/app/components/TransactionInfo/index.tsx
@@ -109,7 +109,7 @@ class TransactionInfo extends React.Component<Props> {
       };
       details = [{
         label: 'Amount',
-        value: <Unit value={tx.value} showFiat />,
+        value: tx.value ? <Unit value={tx.value} showFiat /> : <em>N/A</em>,
       }, {
         label: 'Memo',
         value: tx.memo || <em>N/A</em>,

--- a/src/app/components/TransactionInfo/style.less
+++ b/src/app/components/TransactionInfo/style.less
@@ -118,6 +118,10 @@
           opacity: 0.7;
           font-size: 0.8rem;
         }
+
+        em {
+          opacity: 0.5;
+        }
       }
     }
   }

--- a/src/app/components/TransactionList/index.tsx
+++ b/src/app/components/TransactionList/index.tsx
@@ -122,7 +122,11 @@ class TransactionList extends React.Component<Props> {
               type="lightning"
               timestamp={timestamp}
               status={status}
-              delta={status === 'complete' && new BN(invoice.amt_paid_sat)}
+              delta={
+                status === 'complete' &&
+                !!invoice.amt_paid_sat &&
+                new BN(invoice.amt_paid_sat)
+              }
               onClick={onClick}
             />
           ),

--- a/src/app/lib/lnd-http/types.ts
+++ b/src/app/lib/lnd-http/types.ts
@@ -107,9 +107,9 @@ export interface LightningInvoice {
   creation_date: string;
   settle_date: string;
   expiry: string;
-  value: string;
-  amt_paid_sat: string;
-  amt_paid_msat: string;
+  value?: string;
+  amt_paid_sat?: string;
+  amt_paid_msat?: string;
   settle_index: string;
   add_index: string;
   payment_request: string;
@@ -118,7 +118,7 @@ export interface LightningInvoice {
   cltv_expiry: number;
   receipt: number;
   description_hash: string;
-  memo: string;
+  memo?: string;
   fallback_addr: string;
   private: boolean;
   r_hash: string;

--- a/src/app/lib/lnd-http/types.ts
+++ b/src/app/lib/lnd-http/types.ts
@@ -195,7 +195,7 @@ export interface DecodePaymentRequestResponse {
   description_hash: string;
   route_hints: RouteHint[];
   destination: string;
-  num_satoshis: string;
+  num_satoshis?: string;
   cltv_expiry: string;
   fallback_addr: string;
 }

--- a/src/app/lib/lnd-http/types.ts
+++ b/src/app/lib/lnd-http/types.ts
@@ -228,7 +228,7 @@ export interface SendPaymentResponse {
 };
 
 export interface CreateInvoiceArguments {
-  value: string;
+  value?: string;
   memo?: string;
   expiry?: string | number;
   fallback_addr?: string;

--- a/src/app/modules/payment/actions.ts
+++ b/src/app/modules/payment/actions.ts
@@ -1,10 +1,13 @@
 import { SendPaymentArguments, CreateInvoiceArguments } from 'lib/lnd-http';
 import types from './types';
 
-export function checkPaymentRequest(payload: string) {
+export function checkPaymentRequest(paymentRequest: string, amount?: string) {
   return {
     type: types.CHECK_PAYMENT_REQUEST,
-    payload,
+    payload: {
+      paymentRequest,
+      amount,
+    },
   };
 }
 

--- a/src/app/modules/payment/reducers.ts
+++ b/src/app/modules/payment/reducers.ts
@@ -93,7 +93,7 @@ export default function channelsReducers(
         ...state,
         paymentRequests: {
           ...state.paymentRequests,
-          [action.payload]: {
+          [action.payload.paymentRequest]: {
             data: null,
             error: null,
             isLoading: true,

--- a/src/app/modules/payment/sagas.ts
+++ b/src/app/modules/payment/sagas.ts
@@ -40,7 +40,7 @@ export function* handleCreateInvoice(action: ReturnType<typeof createInvoice>): 
 }
 
 export function* handleCheckPaymentRequest(action: ReturnType<typeof checkPaymentRequest>): SagaIterator {
-  const paymentRequest = action.payload;
+  const { paymentRequest, amount } = action.payload;
   try {
     const nodeLib: Yielded<typeof selectNodeLibOrThrow> = yield select(selectNodeLibOrThrow);
     const decodedRequest: Yielded<typeof nodeLib.decodePaymentRequest> = yield call(nodeLib.decodePaymentRequest, paymentRequest);
@@ -49,7 +49,7 @@ export function* handleCheckPaymentRequest(action: ReturnType<typeof checkPaymen
       call(
         nodeLib.queryRoutes,
         decodedRequest.destination,
-        decodedRequest.num_satoshis,
+        amount || decodedRequest.num_satoshis || '1',
         { num_routes: 1 },
       ),
     ]);

--- a/src/app/prompts/payment.less
+++ b/src/app/prompts/payment.less
@@ -56,6 +56,31 @@
         opacity: 0.7;
       }
     }
+
+    // Ant overrides
+    .ant-input-group.ant-input-group-compact {
+      display: flex;
+    }
+
+    .ant-select-selection-selected-value {
+      font-size: 0.85rem;
+    }
+
+    .ant-form-explain {
+      display: flex;
+      font-size: 0.75rem;
+      margin: 0.2rem 0 1rem;
+
+      > span {
+        margin-right: 0.5rem;
+      }
+
+      > .is-fiat {
+        flex: 1;
+        text-align: right;
+        font-size: 0.85rem;
+      }
+    }
   }
 
   &-description {
@@ -90,6 +115,11 @@
 
   &-row {
     border-bottom: 1px solid rgba(#000, 0.05);
+
+    &.is-large {
+      // tr height behaves like min-height
+      height: 4.2rem;
+    }
 
     &:last-child {
       border: none;

--- a/src/app/prompts/payment.less
+++ b/src/app/prompts/payment.less
@@ -65,22 +65,6 @@
     .ant-select-selection-selected-value {
       font-size: 0.85rem;
     }
-
-    .ant-form-explain {
-      display: flex;
-      font-size: 0.75rem;
-      margin: 0.2rem 0 1rem;
-
-      > span {
-        margin-right: 0.5rem;
-      }
-
-      > .is-fiat {
-        flex: 1;
-        text-align: right;
-        font-size: 0.85rem;
-      }
-    }
   }
 
   &-description {

--- a/src/app/prompts/payment.tsx
+++ b/src/app/prompts/payment.tsx
@@ -14,9 +14,9 @@ import { fromBaseToUnit, fromUnitToBase } from 'utils/units';
 import { Denomination, denominationSymbols } from 'utils/constants';
 import { typedKeys } from 'utils/ts';
 import { sendPayment, checkPaymentRequest } from 'modules/payment/actions';
+import { PaymentRequestData } from 'modules/payment/types';
 import { AppState } from 'store/reducers';
 import './payment.less';
-import { PaymentRequestData } from 'modules/payment/types';
 
 interface StateProps {
   paymentRequests: AppState['payment']['paymentRequests'];


### PR DESCRIPTION
Closes #75

### Description

Allows the creation, viewing, and payment of invoices without an amount specified. The `makeInvoice` prompt, however, does not have the ability to do this, due to the WebLN spec not accounting for this (discussion for that over here https://github.com/wbobeirne/webln/issues/13)

I've created #118 since this introduces a hefty amount of copy-paste for amount inputs. I hate to kick this can down the road, but I didn't want to have to change _too_ much to get this working right now.

### Steps to Test

1. Generate an invoice, and check the "any amount" checkbox. Confirm invoice is created without amount specified
    * You can check on https://lndecode.com/
2. Make a payment using a BOLT-11 link or WebLN that has no amount specified. Confirm you had to specify the amount in the prompt, and that it worked.
    * Tippin.me is a great site for testing this, just tip yourself.
3. Make a payment using the Send form within the Joule popup. Confirm you had to specify the amount in the form, and that it worked.

## Screenshots

### WebLN prompt

<img width="350" alt="screen shot 2018-12-28 at 5 09 35 pm" src="https://user-images.githubusercontent.com/649992/50529530-88b56300-0ac3-11e9-8341-dc9f913afdc3.png">

### Send form

<img width="300" alt="screen shot 2018-12-28 at 5 10 05 pm" src="https://user-images.githubusercontent.com/649992/50529534-979c1580-0ac3-11e9-8980-65cd47f65bae.png">


### Create invoice form

<img width="300" alt="screen shot 2018-12-28 at 5 09 49 pm" src="https://user-images.githubusercontent.com/649992/50529527-80f5be80-0ac3-11e9-90b6-332567b18cb5.png">
