### PR TITLE
Handle offline nodes on transactions and channels list

### DIFF
--- a/src/app/modules/account/sagas.ts
+++ b/src/app/modules/account/sagas.ts
@@ -4,7 +4,10 @@ import BN from 'bn.js';
 import { selectNodeLibOrThrow } from 'modules/node/selectors';
 import { getNodePubKey } from 'modules/node/sagas';
 import { requirePassword } from 'modules/crypto/sagas';
+import { safeGetNodeInfo } from 'utils/misc';
 import types, { Account } from './types';
+
+
 
 export function* handleGetAccountInfo(): SagaIterator {
   try {
@@ -62,7 +65,7 @@ export function* handleGetTransactions(): SagaIterator {
       .map(payment => payment.path[payment.path.length - 1])
       .filter((id, idx, ids) => ids.indexOf(id) === idx);
     const paymentNodes: Array<Yielded<typeof nodeLib.getNodeInfo>> = yield all(
-      paymentNodeIds.map(id => call(nodeLib.getNodeInfo, id))
+      paymentNodeIds.map(id => call(safeGetNodeInfo, nodeLib, id))
     );
     const payments = paymentsRes.payments.map(p => {
       const nodeResponse = paymentNodes.find(

--- a/src/app/modules/channels/sagas.ts
+++ b/src/app/modules/channels/sagas.ts
@@ -1,6 +1,7 @@
 import { SagaIterator } from 'redux-saga';
 import { takeLatest, select, call, all, put } from 'redux-saga/effects';
 import { selectNodeLibOrThrow } from 'modules/node/selectors';
+import { safeGetNodeInfo } from 'utils/misc';
 import types from './types';
 
 export function* handleGetChannels(): SagaIterator {
@@ -8,7 +9,7 @@ export function* handleGetChannels(): SagaIterator {
     const nodeLib: Yielded<typeof selectNodeLibOrThrow> = yield select(selectNodeLibOrThrow);
     const { channels }: Yielded<typeof nodeLib.getChannels> = yield call(nodeLib.getChannels);
     const channelsNodeInfo: Array<Yielded<typeof nodeLib.getNodeInfo>> = yield all(
-      channels.map(channel => call(nodeLib.getNodeInfo, channel.remote_pubkey))
+      channels.map(channel => call(safeGetNodeInfo, nodeLib, channel.remote_pubkey))
     );
     const payload = channels.map((channel, i) => ({
       ...channel,

--- a/src/app/utils/misc.ts
+++ b/src/app/utils/misc.ts
@@ -1,5 +1,30 @@
+import { LndHttpClient, GetNodeInfoResponse } from 'lib/lnd-http';
+
 export function sleep(time: number) {
   return new Promise(resolve => {
     setTimeout(resolve, time);
   });
+}
+
+// Run getNodeInfo, but if it fails, return a spoofed node object
+export async function safeGetNodeInfo(
+  lib: LndHttpClient,
+  pubkey: string,
+): Promise<GetNodeInfoResponse> {
+  try {
+    const node = await lib.getNodeInfo(pubkey);
+    return node;
+  } catch (err) {
+    return {
+      total_capacity: 0,
+      num_channels: 0,
+      node: {
+        alias: '<Offline node>',
+        color: '000000',
+        addresses: [],
+        last_update: 0,
+        pub_key: pubkey,
+      },
+    };
+  }
 }


### PR DESCRIPTION
<!-- New to the project? Check out the Contributor Guidelines! -->
<!-- https://github.com/wbobeirne/joule-extension/wiki/Contributor-Guidelines -->

No issue opened, but a couple of folks reported this one.

### Description

Provides a fallback stubbed node object in cases where the node we fetch more info about is offline.

### Steps to Test

1. Make a transaction with a node you control
2. Disconnect that node from the network
3. Load your transactions, and confirm that it displays as `<Offline node>`

## Screenshots

### Before

<img width="379" alt="screen shot 2018-12-30 at 2 33 47 pm" src="https://user-images.githubusercontent.com/649992/50550512-f2f31280-0c3f-11e9-86f0-0feff199bba9.png">

### After

<img width="402" alt="screen shot 2018-12-30 at 2 34 30 pm" src="https://user-images.githubusercontent.com/649992/50550520-0900d300-0c40-11e9-8f2e-5e6791661916.png">
