### PR TITLE
Fixed deposit button not working if password is dismissed

### DIFF
--- a/src/app/components/AccountInfo/index.tsx
+++ b/src/app/components/AccountInfo/index.tsx
@@ -98,12 +98,7 @@ class AccountInfo extends React.Component<Props, State> {
       </div>
     );
   }
-  /*
-    Use store modal state until user successfully enters
-    password. Deposit modal can be reopened with a
-    subsequent double tap instead of closing and
-    re-opening the application.
-  */
+
   private openDepositModal = () => {
    const password = this.props.password;
     this.setState({

--- a/src/app/components/AccountInfo/index.tsx
+++ b/src/app/components/AccountInfo/index.tsx
@@ -11,6 +11,7 @@ import './style.less';
 
 interface StateProps {
   account: AppState['account']['account'];
+  password: AppState['crypto']['password'];
   modal: AppState['crypto']['depositModal'];
 }
 
@@ -104,10 +105,16 @@ class AccountInfo extends React.Component<Props, State> {
     re-opening the application.
   */
   private openDepositModal = () => {
+   const password = this.props.password;
     this.setState({
       isDepositModalOpen: true
     })
     setTimeout(()=>{
+      password === null ?
+        this.setState({
+      isDepositModalOpen: false
+    })
+    :
       this.setState({
         isDepositModalOpen: this.props.modal
       });
@@ -119,6 +126,7 @@ class AccountInfo extends React.Component<Props, State> {
 export default connect<StateProps, DispatchProps, {}, AppState>(
   state => ({
     account: state.account.account,
+    password: state.crypto.password,
     modal: state.crypto.depositModal
   }),
   {

--- a/src/app/components/AccountInfo/index.tsx
+++ b/src/app/components/AccountInfo/index.tsx
@@ -11,6 +11,7 @@ import './style.less';
 
 interface StateProps {
   account: AppState['account']['account'];
+  modal: AppState['crypto']['depositModal'];
 }
 
 interface DispatchProps {
@@ -96,14 +97,29 @@ class AccountInfo extends React.Component<Props, State> {
       </div>
     );
   }
-
-  private openDepositModal = () => this.setState({ isDepositModalOpen: true });
+  /*
+    Use store modal state until user successfully enters
+    password. Deposit modal can be reopened with a
+    subsequent double tap instead of closing and
+    re-opening the application.
+  */
+  private openDepositModal = () => {
+    this.setState({
+      isDepositModalOpen: true
+    })
+    setTimeout(()=>{
+      this.setState({
+        isDepositModalOpen: this.props.modal
+      });
+    },0)
+  }
   private closeDepositModal = () => this.setState({ isDepositModalOpen: false });
 }
 
 export default connect<StateProps, DispatchProps, {}, AppState>(
   state => ({
     account: state.account.account,
+    modal: state.crypto.depositModal
   }),
   {
     getAccountInfo,

--- a/src/app/modules/crypto/reducers.ts
+++ b/src/app/modules/crypto/reducers.ts
@@ -16,7 +16,7 @@ export const INITIAL_STATE: CryptoState = {
   password: null,
   testCipher: null,
   isRequestingPassword: false,
-  depositModal: false
+  depositModal: true,
 };
 
 export default function cryptoReducers(

--- a/src/app/modules/crypto/reducers.ts
+++ b/src/app/modules/crypto/reducers.ts
@@ -7,6 +7,7 @@ export interface CryptoState {
   password: null | string;
   testCipher: null | string;
   isRequestingPassword: boolean;
+  depositModal: boolean;
 }
 
 export const INITIAL_STATE: CryptoState = {
@@ -15,6 +16,7 @@ export const INITIAL_STATE: CryptoState = {
   password: null,
   testCipher: null,
   isRequestingPassword: false,
+  depositModal: false
 };
 
 export default function cryptoReducers(
@@ -52,12 +54,14 @@ export default function cryptoReducers(
       return {
         ...state,
         isRequestingPassword: true,
+        depositModal: true,
       }
 
     case types.CANCEL_PASSWORD:
       return {
         ...state,
         isRequestingPassword: false,
+        depositModal: false,
       };
 
     case types.LOGOUT:


### PR DESCRIPTION
Closes #105 

### Fixed deposit button not working if password dismissed

Initially set deposit modal to true on local state. Then used a modal state from the reducer until the user successfully enters the password. Cancel password action sets modal back to false since before it was stuck on true after CANCEL_PASSWORD action. After entering password the deposit button will still show address until closing the app. Only thing is that subsequent attempts after dismissing password prompt requires double tap instead of single tap.

*edit - solved double tap issue.