### PR TITLE
Fix deposit not showing after opening

### DIFF
--- a/src/app/components/AccountInfo/DepositModal.less
+++ b/src/app/components/AccountInfo/DepositModal.less
@@ -1,4 +1,5 @@
 .DepositModal {
+  width: 260px;
   text-align: center;
 
   &-qr {

--- a/src/app/components/AccountInfo/DepositModal.tsx
+++ b/src/app/components/AccountInfo/DepositModal.tsx
@@ -27,8 +27,8 @@ interface OwnProps {
 type Props = StateProps & DispatchProps & OwnProps;
 
 class DepositModal extends React.Component<Props> {
-  componentDidUpdate(prevProps: Props) {
-    if (this.props.isOpen && !prevProps.isOpen) {
+  componentWillUpdate(nextProps: Props) {
+    if (!this.props.isOpen && nextProps.isOpen) {
       // Fire even if depositAddress is in store in case we need to cycle
       this.props.getDepositAddress();
     }
@@ -42,6 +42,7 @@ class DepositModal extends React.Component<Props> {
       onClose,
       hasPassword,
     } = this.props;
+    const isVisible = !!isOpen && !!(hasPassword || fetchDepositAddressError);
 
     let content;
     if (depositAddress) {
@@ -86,7 +87,7 @@ class DepositModal extends React.Component<Props> {
     return (
       <Modal
         title="BTC Address"
-        visible={isOpen && hasPassword}
+        visible={isVisible}
         onCancel={onClose}
         okButtonProps={{ style: { display: 'none'} }}
         centered


### PR DESCRIPTION
<!-- New to the project? Check out the Contributor Guidelines! -->
<!-- https://github.com/wbobeirne/joule-extension/wiki/Contributor-Guidelines -->

Closes #105, replaces #127.

### Description

Fixes the modal not opening after canceling entering password. Also has a bonus fix for the modal expanding in width after loading.

### Steps to Test

1. Open deposit modal, close password. Confirm you see error.
2. Click deposit again. Confirm it pops up.
3. Enter password, confirm deposit shows.
