### PR TITLE
Skip Splash screen when onboarding opens in full page

### DIFF
--- a/src/app/components/Splash/index.tsx
+++ b/src/app/components/Splash/index.tsx
@@ -8,6 +8,18 @@ interface Props {
 }
 
 export default class Splash extends React.Component<Props> {
+  componentDidMount() {
+    if (process.env.APP_CONTAINER === 'page') {
+      browser.storage.local.get('skipSplash').then(value => {
+        if (value && value.skipSplash) {
+          browser.storage.local.remove('skipSplash').then(() => {
+            this.handleContinue();
+          });
+        }
+      });
+    }
+  }
+
   render() {
     return (
       <div className="Splash">
@@ -34,7 +46,10 @@ export default class Splash extends React.Component<Props> {
     if (process.env.APP_CONTAINER === 'page') {
       this.props.handleContinue();
     } else {
-      browser.runtime.openOptionsPage();
+      browser.storage.local.set({ skipSplash: true }).then(() => {
+        browser.runtime.openOptionsPage();
+        setTimeout(window.close, 100);
+      });
     }
   };
 }


### PR DESCRIPTION
Closes #110 

### Description

Pretty simple update to skip the redundant splash screen when the `Get Started` button is clicked on the popup.

### Steps to Test

1. Reset your connection settings to restart the onboarding process
2. Click on the Joule toolbar icon
3. Click on the `Get Started` button
4. Confirm the full page tab shows the Choose node screen



### Screenshots

![joule_get_started](https://user-images.githubusercontent.com/1356600/50917964-f1c6a000-140c-11e9-952f-6cea9a5f5e74.gif)


### Development Notes

I used `browser.storage.local` to pass the `skipSplash` flag to the full page from the popup. This ended up being the simplest solution. 

I first thought to pass a querystring param to the options page but this isn't possible unless you manually create a new tab with `browser.tabs.create({ url: browser.extension.getURL('options.html') });`. This would require the `tabs` permission so I knew that wouldn't be a good choice. 

I also thought to use the background script to set the flag. This way would require using `browser.runtime.sendMessage` to pass the data to the background. Then there would need to be a handler with this flag as it's only state. This approach felt like overkill and much complication for a simple bool that only needs to live for a split second. 