### PR TITLE
Fix decryptSyncedData raising an error

### DIFF
--- a/src/app/modules/sync/sagas.ts
+++ b/src/app/modules/sync/sagas.ts
@@ -82,7 +82,7 @@ export function* decryptSyncedData(syncConfig: SyncConfig<any>, data: any): Saga
   }
 
   // Call their respective actions
-  const decryptedItem = decryptData(data, password, salt);
+  const decryptedItem = decryptData(data.data, password, salt);
   const payload = migrateSyncedData(syncConfig, decryptedItem);
   yield put(syncConfig.action(payload));
   yield put({ type: types.FINISH_DECRYPT});


### PR DESCRIPTION
Closes #140

### Description

Fixes `decryptSyncedData` function failing. The issue #140 has a detailed explanation of the problem.

### Steps to Test

1. Clear your local browser storage
2. Setup joule to connect to your node
3. Refresh the options page
4. Confirm you can view your deposit address successfully after entering your password
5. Confirm you can add a new peer
6. Confirm you can open a channel
