### PR TITLE
Fix incorrect storage data retrieved by prompts

### DIFF
--- a/src/content_script/runSelector.ts
+++ b/src/content_script/runSelector.ts
@@ -1,5 +1,5 @@
-import { browser } from 'webextension-polyfill-ts';
 import { AppState, combineInitialState } from 'store/reducers';
+import { storageSyncGet } from 'utils/sync';
 
 type Selector<T> = (s: AppState) => T;
 
@@ -8,17 +8,13 @@ export default async function runSelector<T>(
   storageKey: string,
   stateKey: keyof AppState,
 ): Promise<T> {
-  const storageData = await browser.storage.sync.get(storageKey);
-  // storageData looks like { 'settings': { version: 1, data: {...} } }
-  const keyData = storageData[storageKey] || {};
-  // keyData looks like { version: 1, data: {...} }
-  // we need to pluck out the inner data value
-  const dataWithoutVersion = keyData.data || {};
+  const storageData = await storageSyncGet([storageKey]);
+  const keyData = storageData && storageData[storageKey] || {};
   const state = {
     ...combineInitialState,
     [stateKey]: {
       ...combineInitialState[stateKey],
-      ...dataWithoutVersion,
+      ...keyData,
     },
   } as AppState;
   return selector(state);

--- a/src/content_script/runSelector.ts
+++ b/src/content_script/runSelector.ts
@@ -9,12 +9,16 @@ export default async function runSelector<T>(
   stateKey: keyof AppState,
 ): Promise<T> {
   const storageData = await browser.storage.sync.get(storageKey);
+  // storageData looks like { 'settings': { version: 1, data: {...} } }
   const keyData = storageData[storageKey] || {};
+  // keyData looks like { version: 1, data: {...} }
+  // we need to pluck out the inner data value
+  const dataWithoutVersion = keyData.data || {};
   const state = {
     ...combineInitialState,
     [stateKey]: {
       ...combineInitialState[stateKey],
-      ...keyData,
+      ...dataWithoutVersion,
     },
   } as AppState;
   return selector(state);


### PR DESCRIPTION
Closes #144

### Description

Fixes `runSelector` not properly retrieving new versioned data from from browser storage. The issue #144 has a detailed explanation of the problem.

### Steps to Test

1. Visit a website that has WebLN support such as lightningspin.com or tippin.me (login required)
2. When the page loads, the Joule authorization prompt will popup
3. Ensure `Remember my choice` is checked
4. Click on `Confirm`
5. Refresh the website
6. Ensure the authorize popup is not displayed
7. Open the browser devtools console and type `webln.isEnabled`
8. Confirm the value `true` is displayed
