### PR TITLE
Fix chains object response

### DIFF
--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -33,7 +33,13 @@ export class LndHttpClient {
         testnet: false,
         chains: [],
       },
-    );
+    ).then(res => {
+      // API can return chain as { chain: 'bitcoin', network: 'testnet' }
+      res.chains = res.chains.map((chain: any) => {
+        return chain.chain || chain;
+      });
+      return res;
+    });
   };
 
   getNodeInfo = (pubKey: string) => {


### PR DESCRIPTION
<!-- New to the project? Check out the Contributor Guidelines! -->
<!-- https://github.com/wbobeirne/joule-extension/wiki/Contributor-Guidelines -->

Closes #147

### Description

Forces chains response into string, even if object.

### Steps to Test

1. Run the latest lightning-app release (this is how I got it to happen) and try to connect your node to it. Confirm it works.
