### PR TITLE
Show chain on node confirm screen

### DIFF
--- a/src/app/components/SelectNode/ConfirmNode.tsx
+++ b/src/app/components/SelectNode/ConfirmNode.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button } from 'antd';
 import { GetInfoResponse } from 'lib/lnd-http';
+import { blockchainDisplayName, CHAIN_TYPE } from 'utils/constants';
 import './ConfirmNode.less';
 
 interface Props {
@@ -12,12 +13,16 @@ interface Props {
 export default class ConfirmNode extends React.Component<Props> {
   render() {
     const { nodeInfo, onConfirm, onCancel } = this.props;
+    const chain = nodeInfo.chains[0] as CHAIN_TYPE;
     const rows = [{
       label: 'Alias',
       value: nodeInfo.alias,
     }, {
       label: 'Version',
       value: nodeInfo.version.split(' ')[0],
+    }, {
+      label: 'Chain',
+      value: blockchainDisplayName[chain],
     }, {
       label: 'Testnet',
       value: JSON.stringify(!!nodeInfo.testnet),


### PR DESCRIPTION
No associated issue

### Description

Just a quick one, shows which chain your node is on the confirm screen.

### Steps to Test

1. Go through onboarding, confirm it shows the right chain for your node.

### Screenshots

<img width="400" alt="screen shot 2019-01-18 at 4 30 50 pm" src="https://user-images.githubusercontent.com/649992/51413953-98621d80-1b3e-11e9-83a4-2a480f645ee5.png">
