### PR TITLE
Fix decryptSyncedData raising an error (Pt. 2)

### DIFF
--- a/src/app/modules/sync/sagas.ts
+++ b/src/app/modules/sync/sagas.ts
@@ -71,7 +71,7 @@ export function* decryptSyncedData(syncConfig: SyncConfig<any>, data: any): Saga
     return;
   }
 
-  // Get things needed for encryption
+  // Get things needed for decryption
   const salt = yield select(selectSalt);
   let password = yield select(selectPassword);
 
@@ -81,7 +81,7 @@ export function* decryptSyncedData(syncConfig: SyncConfig<any>, data: any): Saga
     password = yield select(selectPassword);
   }
 
-  // Call their respective actions
+  // Migrate the data once it's decrypted & call the config action
   const decryptedItem = decryptData(data, password, salt);
   const payload = migrateSyncedData(syncConfig, decryptedItem);
   yield put(syncConfig.action(payload));

--- a/src/app/modules/sync/sagas.ts
+++ b/src/app/modules/sync/sagas.ts
@@ -82,7 +82,7 @@ export function* decryptSyncedData(syncConfig: SyncConfig<any>, data: any): Saga
   }
 
   // Call their respective actions
-  const decryptedItem = decryptData(data.data, password, salt);
+  const decryptedItem = decryptData(data, password, salt);
   const payload = migrateSyncedData(syncConfig, decryptedItem);
   yield put(syncConfig.action(payload));
   yield put({ type: types.FINISH_DECRYPT});

--- a/src/app/utils/sync.ts
+++ b/src/app/utils/sync.ts
@@ -124,11 +124,7 @@ export async function storageSyncGet(keys: string[]) {
       }
       // Run migrations on unencrypted data
       const config = getConfigByKey(key);
-      if (config.encrypted) {
-        prev[key] = res;
-      } else {
-        prev[key] = migrateSyncedData(config, res);
-      }
+      prev[key] = migrateSyncedData(config, res);
       return prev;
     }, {} as { [key: string]: any });
   } catch(err) {
@@ -143,6 +139,10 @@ export function migrateSyncedData(config: SyncConfig<any>, item: SyncData<any>) 
       version: 1,
       data: item,
     };
+  }
+  // If it's still encrypted, we can't migrate the data, so just send it back
+  if (config.encrypted && typeof item.data === 'string') {
+    return item.data;
   }
   // Throw off some potential warnings and early returns
   if (item.version === config.version) {


### PR DESCRIPTION
### What This Does

Addendum to #142. I found that after merging that one in, I was actually getting the problem that that PR was meant to fix. The issue is that you can potentially have two states in local storage for the encrypted node data, either the old flat style:

```
node-encryped | 'U2FsdGVkX1/DLtlI...'
```
or the new style with a version number
```
node-encryped | '{"data": "U2FsdGVkX1/DLtlI...", "version": 1}'
```

While unencrypted storage items had this problem as well, we are running them through `migrateSyncedData` which normalizes them to the new style. Encrypted data was _not_ being run through though, since it couldn't be migrated. This change runs it through migration anyway, but bails out if it detects that it's still encrypted. This should fix any and all remaining issues around them not having the same data shape, everything should be normalized now.

<sup>P.S. I'm sorry for having typoed the key as `node-encryped`. We're pretty much gonna have to live with this one forever. My bad.</sup>


### Steps to Test

1. Using your existing new style config, or after resetting node and onboarding, open the deposit modal and confirm it works.
2. Run the following code to switch your stored config to the old style:
```
chrome.storage.sync.get(['node-encryped'], (res) => {
  chrome.storage.sync.set({ 'node-encryped': res['node-encryped'].data });
});
```
3. Reload the page, open the deposit modal, and confirm it works.
4. Go into your settings, change your admin macaroon, and confirm it works.
5. Open the deposit modal again, confirm it works.