### PR TITLE
Add safe rates selector

### DIFF
--- a/src/app/components/AmountField/index.tsx
+++ b/src/app/components/AmountField/index.tsx
@@ -11,6 +11,7 @@ import {
   fromBitcoinToUnit,
 } from 'utils/units';
 import { getNodeChain } from 'modules/node/selectors';
+import { getChainRates } from 'modules/rates/selectors';
 import { AppState } from 'store/reducers';
 import './index.less';
 
@@ -32,7 +33,7 @@ interface StateProps {
   denomination: AppState['settings']['denomination'];
   fiat: AppState['settings']['fiat'];
   isNoFiat: AppState['settings']['isNoFiat'];
-  rates: AppState['rates']['rates'];
+  rates: ReturnType<typeof getChainRates>;
   chain: ReturnType<typeof getNodeChain>;
 }
 
@@ -190,7 +191,7 @@ class AmountField extends React.Component<Props, State> {
   };
 
   private updateBothValues = (name: string, val: string) => {
-    const { fiat, chain, rates } = this.props;
+    const { fiat, rates } = this.props;
     const { denomination } = this.state;
     let { value, valueFiat } = this.state;
   
@@ -202,13 +203,13 @@ class AmountField extends React.Component<Props, State> {
       value = val;
       if (rates) {
         const btc = fromUnitToBitcoin(value, denomination);
-        valueFiat = (rates[chain][fiat] * parseFloat(btc)).toFixed(2);
+        valueFiat = (rates[fiat] * parseFloat(btc)).toFixed(2);
       }
     }
     else {
       valueFiat = val;
       if (rates) {
-        const btc = (parseFloat(valueFiat) / rates[chain][fiat]).toFixed(8);
+        const btc = (parseFloat(valueFiat) / rates[fiat]).toFixed(8);
         value = fromBitcoinToUnit(btc, denomination);
       }
     }
@@ -231,7 +232,7 @@ export default connect<StateProps, {}, OwnProps, AppState>(
     denomination: state.settings.denomination,
     fiat: state.settings.fiat,
     isNoFiat: state.settings.isNoFiat,
-    rates: state.rates.rates,
+    rates: getChainRates(state),
     chain: getNodeChain(state),
   }),
 )(AmountField);

--- a/src/app/components/Unit.tsx
+++ b/src/app/components/Unit.tsx
@@ -9,13 +9,14 @@ import { fromBaseToUnit, fromUnitToFiat } from 'utils/units';
 import { commaify } from 'utils/formatters';
 import { AppState } from 'store/reducers';
 import { getNodeChain } from 'modules/node/selectors';
+import { getChainRates } from 'modules/rates/selectors';
 
 interface StateProps {
-  rates: AppState['rates']['rates'];
   fiat: AppState['settings']['fiat'];
   denomination: AppState['settings']['denomination'];
   isFiatPrimary: AppState['settings']['isFiatPrimary'];
   isNoFiat: AppState['settings']['isNoFiat'];
+  rates: ReturnType<typeof getChainRates>;
   chain: ReturnType<typeof getNodeChain>;
 }
 
@@ -54,11 +55,11 @@ class Unit extends React.Component<Props> {
     </>;
 
     let fiatEl = '';
-    if (rates && rates[chain] && rates[chain][fiat]) {
+    if (rates) {
       fiatEl = fromUnitToFiat(
         value,
         Denomination.SATOSHIS,
-        rates[chain][fiat],
+        rates[fiat],
         fiatSymbols[fiat],
       );
     }
@@ -81,10 +82,10 @@ class Unit extends React.Component<Props> {
 }
 
 export default connect<StateProps, {}, OwnProps, AppState>(state => ({
-  rates: state.rates.rates,
   fiat: state.settings.fiat,
   denomination: state.settings.denomination,
   isFiatPrimary: state.settings.isFiatPrimary,
   isNoFiat: state.settings.isNoFiat,
+  rates: getChainRates(state),
   chain: getNodeChain(state),
 }))(Unit);

--- a/src/app/modules/rates/reducers.ts
+++ b/src/app/modules/rates/reducers.ts
@@ -2,7 +2,7 @@ import { CHAIN_TYPE } from 'utils/constants';
 import types, { RatesMap } from './types';
 
 export type Rates = {
-  [key in CHAIN_TYPE]: RatesMap
+  [key in CHAIN_TYPE]: RatesMap | undefined;
 }
 
 export interface RatesState {

--- a/src/app/modules/rates/selectors.ts
+++ b/src/app/modules/rates/selectors.ts
@@ -1,3 +1,9 @@
 import { AppState as S } from 'store/reducers';
+import { getNodeChain } from 'modules/node/selectors';
 
 export const selectRates = (s: S) => s.rates.rates;
+export const getChainRates = (s: S) => {
+  const chain = getNodeChain(s);
+  const rates = selectRates(s);
+  return rates && rates[chain] ? rates[chain] : null;
+};

--- a/src/app/prompts/invoice.tsx
+++ b/src/app/prompts/invoice.tsx
@@ -13,6 +13,7 @@ import { createInvoice } from 'modules/payment/actions';
 import { AppState } from 'store/reducers';
 import './invoice.less';
 import { getNodeChain } from 'modules/node/selectors';
+import { getChainRates } from 'modules/rates/selectors';
 
 interface StateProps {
   invoice: AppState['payment']['invoice'];
@@ -21,7 +22,7 @@ interface StateProps {
   denomination: AppState['settings']['denomination'];
   fiat: AppState['settings']['fiat'];
   isNoFiat: AppState['settings']['isNoFiat'];
-  rates: AppState['rates']['rates'];
+  rates: ReturnType<typeof getChainRates>;
   chain: ReturnType<typeof getNodeChain>;
 }
 
@@ -205,11 +206,11 @@ class InvoicePrompt extends React.Component<Props, State> {
       }
     }
 
-    if (rates && rates[chain][fiat] && !isNoFiat) {
+    if (rates && !isNoFiat) {
       const fiatAmt = fromUnitToFiat(
         value,
         denomination,
-        rates[chain][fiat],
+        rates[fiat],
         fiatSymbols[fiat],
       );
       helpPieces.push(
@@ -297,7 +298,7 @@ export default connect<StateProps, DispatchProps, {}, AppState>(
     denomination: state.settings.denomination,
     fiat: state.settings.fiat,
     isNoFiat: state.settings.isNoFiat,
-    rates: state.rates.rates,
+    rates: getChainRates(state),
     chain: getNodeChain(state),
   }),
   { createInvoice },


### PR DESCRIPTION
Catches a bug with no associated issue.

### Description

The rates type was incorrect, sometimes the rates can be undefined in certain cases. This fixes the type to indicate it may be undefined, and adds a selector that cuts down some boilerplate code.

### Steps to Test

1. Attempt to makeInvoice on the old code, confirm you get an error (lightningroulette.com is a good way to do this) 
2. Switch to this branch, attempt to makeInvoice, confirm it works.
