### PR TITLE
Fix transactions with no amount field causing a crash

### DIFF
--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -166,6 +166,8 @@ export class LndHttpClient {
     ).then(res => {
       res.transactions = res.transactions.map(tx => ({
         total_fees: '0',
+        amount: '0',
+        num_confirmations: 0,
         ...tx,
       }));
       return res;


### PR DESCRIPTION
Fixes a small issue I noticed where some transactions don't send an `amount` field. I'm not sure what these transactions are, but I've gone ahead and given it a default of `"0"` just to stop the crashing. Perhaps these transactions should be removed or displayed differently though.