### PR TITLE
Fix blocks_til_maturity not showing in the UI

### DIFF
--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -89,6 +89,12 @@ export class LndHttpClient {
         pending_open_channels: [],
       }
     ).then(res => {
+      const collapse = (chan: any) => ({
+        ...chan,
+        ...chan.channel,
+        // remove nested 'channel' key from the chan spread
+        ...{ channel: undefined },
+      });
       res.pending_open_channels = res.pending_open_channels.map(channel => ({
         status: T.CHANNEL_STATUS.OPENING,
         commit_weight: '0',
@@ -98,15 +104,15 @@ export class LndHttpClient {
         remote_balance: '0',
         local_balance: '0',
         capacity: '0',
-        ...(channel as any).channel,
+        ...collapse(channel),
       }));
       res.pending_closing_channels = res.pending_closing_channels.map(channel => ({
         status: T.CHANNEL_STATUS.CLOSING,
-        closing_txid: channel.closing_txid,
+        closing_txid: '',
         remote_balance: '0',
         local_balance: '0',
         capacity: '0',
-        ...(channel as any).channel,
+        ...collapse(channel),
       }));
       res.waiting_close_channels = res.waiting_close_channels.map(channel => ({
         status: T.CHANNEL_STATUS.WAITING,
@@ -114,7 +120,7 @@ export class LndHttpClient {
         remote_balance: '0',
         local_balance: '0',
         capacity: '0',
-        ...(channel as any).channel,
+        ...collapse(channel),
       }));
       res.pending_force_closing_channels = res.pending_force_closing_channels.map(channel => ({
         status: T.CHANNEL_STATUS.FORCE_CLOSING,
@@ -126,7 +132,7 @@ export class LndHttpClient {
         remote_balance: '0',
         local_balance: '0',
         capacity: '0',
-        ...(channel as any).channel,
+        ...collapse(channel),
       }));
       return res;
     });


### PR DESCRIPTION
Closes #163 

### Description

Fixes the bug described in the issue referenced above.

**Technical**
We were not mapping the top-level keys of the response objects so we discarded all of the data except `remote_balance`, `local_balance` & `capacity` from the `channel` nested object. I changed the code to merge the top-level with the nested keys while mapping the response.

### Steps to Test

1. Force-close one of your channels
2. Hover over the orange icon in the channel list
3. Confirm the tooltip shows the number of blocks as non-zero

### Screenshots

![image](https://user-images.githubusercontent.com/1356600/52844135-ec2a3d00-30d1-11e9-8aae-045183648365.png)
