### PR TITLE
Add Russian ruble fiat

### DIFF
--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -100,6 +100,7 @@ export enum Fiat {
   EUR = 'EUR',
   GBP = 'GBP',
   JPY = 'JPY',
+  RUB = 'RUB',
 }
 
 export const fiatSymbols: { [key in Fiat]: string } = {
@@ -107,6 +108,7 @@ export const fiatSymbols: { [key in Fiat]: string } = {
   EUR: '€',
   GBP: '£',
   JPY: '¥',
+  RUB: '₽'
 };
 
 export const channelStatusText: { [key in CHANNEL_STATUS]: string } = {


### PR DESCRIPTION
### Description
Add Russian rubble currency

### Steps to Test
1. Click `Settings`
2. Select `RUB` in the `currency` selector
3. Got to the main screen and check fiat value

### Screenshots
<img width="403" alt="screen shot 2019-02-16 at 00 55 40" src="https://user-images.githubusercontent.com/922338/52886552-b5156380-3185-11e9-8a0c-7b17367ec2a9.png">
