### PR TITLE
Add channel close instructions

### DIFF
--- a/src/app/components/ChannelInfo/index.less
+++ b/src/app/components/ChannelInfo/index.less
@@ -1,0 +1,31 @@
+@import '~style/variables.less';
+
+.ChannelInfo {
+  &-close {
+    max-width: 260px;
+    margin: 0 auto 2rem;
+
+    &-instructions {
+      font-size: 0.8rem;
+      margin-bottom: 0.2rem;
+    }
+
+    &-command {
+      display: block;
+      font-family: @code-family;
+
+      .ant-input {
+        font-size: 0.75rem;
+      }
+
+      .ant-input-group-addon > span {
+        opacity: 0.6;
+        cursor: pointer;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
+    }
+  }
+}

--- a/src/app/components/ChannelInfo/index.tsx
+++ b/src/app/components/ChannelInfo/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import { connect } from 'react-redux';
-import { Icon, Button, Modal } from 'antd';
+import { Icon, Button, Modal, Input } from 'antd';
 import Identicon from 'components/Identicon';
 import Unit from 'components/Unit';
 import DetailsTable, { DetailsRow } from 'components/DetailsTable';
@@ -13,6 +13,8 @@ import { closeChannel } from 'modules/channels/actions';
 import { ChannelWithNode } from 'modules/channels/types';
 import { channelStatusText } from 'utils/constants';
 import { ellipsisSandwich, enumToClassName } from 'utils/formatters';
+import './index.less';
+import Copy from 'components/Copy';
 
 interface StateProps {
   account: AppState['account']['account'];
@@ -47,6 +49,12 @@ class ChannelInfo extends React.Component<Props> {
     if (channel.status === CHANNEL_STATUS.OPEN) {
       statusClass = `${statusClass} is-${channel.active ? 'active' : 'inactive'}`;
     }
+
+    let closeCommand = '';
+    if (channel.status === CHANNEL_STATUS.OPEN) {
+      const txInfo = channel.channel_point.split(':');
+      closeCommand = `lncli closechannel ${txInfo[0]} ${txInfo[1]}`;
+    }
     
     return (
       <div className="ChannelInfo">
@@ -65,7 +73,7 @@ class ChannelInfo extends React.Component<Props> {
 
         <DetailsTable details={this.getChannelDetails()} />
 
-        {/* TODO: show button when LND issue #2730 is resolved */}
+        {/* TODO: show button instead of instructions when LND issue #2730 is resolved */}
         {channel.status === CHANNEL_STATUS.OPEN && (
           <div className="ChannelInfo-actions" style={{ display: 'none' }}>
             <Button
@@ -77,6 +85,23 @@ class ChannelInfo extends React.Component<Props> {
             >
               Close Channel
             </Button>
+          </div>
+        )}
+        {channel.status === CHANNEL_STATUS.OPEN && (
+          <div className="ChannelInfo-close">
+            <div className="ChannelInfo-close-instructions">
+              Ready to <strong>close the channel</strong>? Run this:
+            </div>
+            <Input
+              className="ChannelInfo-close-command"
+              value={closeCommand}
+              readOnly
+              addonAfter={
+                <Copy text={closeCommand}>
+                  <span><Icon type="copy" /> Copy</span>
+                </Copy>
+              }
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
Untracked issue

### Description

Due to the outstanding issue of being unable to close a channel via the REST API, I figured a good middleground would be to at least include instructions on how to close a channel via the CLI. This adds an input and copy button of how to close the channel at the bottom of the details menu.

### Steps to Test

1. Click on an open channel
2. Confirm you get valid close instructions
3. Click on a non-open channel
4. Confirm close instructions don't render

### Screenshots

<img width="403" alt="Screen Shot 2019-03-18 at 4 02 00 PM" src="https://user-images.githubusercontent.com/649992/54559880-6f6fd480-4997-11e9-9aeb-d4abe7226511.png">
