### PR TITLE
Default empty array for utxos

### DIFF
--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -375,7 +375,8 @@ export class LndHttpClient {
     return this.request<T.GetUtxosResponse, T.GetUtxosParams>(
       'GET',
       '/v1/utxos',
-      params
+      params,
+      { utxos: [] },
     );
   };
 


### PR DESCRIPTION
Closes #187

### Description

Defaults utxos response to empty array so that utxos aren't false-y after the request has been made.

### Steps to Test

1. Spin up a clean node or spend all of your UTXOs
2. Attempt to load the balance page
3. Success!