### PR TITLE
Zap onboarding button

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "cross-env": "5.2.0",
     "react-hot-loader": "^4.6.3",
     "rimraf": "2.6.2",
+    "string-hash": "1.1.3",
     "webextension-polyfill-ts": "0.8.9",
     "webpack-bundle-analyzer": "3.0.3",
     "webpack-dev-server": "3.1.11",

--- a/src/app/components/Balances/index.tsx
+++ b/src/app/components/Balances/index.tsx
@@ -53,6 +53,13 @@ class Balances extends React.Component<Props, State> {
     // only calculate the stats one time when we have the channels & utxos
     // this approach avoids calculating the stats on every render if the
     // call to calculateBalanaceStats was inside of the render method
+    console.log({
+      isFetchingChannels,
+      isFetchingUtxos,
+      channels,
+      utxos,
+      this.state.stats,
+    });
     if (!isFetchingChannels && !isFetchingUtxos &&
         channels && utxos && !this.state.stats) {
       this.setState({

--- a/src/app/components/Balances/index.tsx
+++ b/src/app/components/Balances/index.tsx
@@ -53,13 +53,6 @@ class Balances extends React.Component<Props, State> {
     // only calculate the stats one time when we have the channels & utxos
     // this approach avoids calculating the stats on every render if the
     // call to calculateBalanaceStats was inside of the render method
-    console.log({
-      isFetchingChannels,
-      isFetchingUtxos,
-      channels,
-      utxos,
-      this.state.stats,
-    });
     if (!isFetchingChannels && !isFetchingUtxos &&
         channels && utxos && !this.state.stats) {
       this.setState({

--- a/src/app/components/SelectNode/SelectType.less
+++ b/src/app/components/SelectNode/SelectType.less
@@ -8,8 +8,8 @@
     font-size: 1.3rem;
 
     .anticon {
-      margin-right: 0.25rem;
-      transform: scale(1.1);
+      margin-right: 0.4rem;
+      transform: scale(1.3);
 
       svg {
         display: block;

--- a/src/app/components/SelectNode/SelectType.tsx
+++ b/src/app/components/SelectNode/SelectType.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button, Collapse, Icon } from 'antd';
 import { NODE_TYPE } from 'utils/constants';
 import LightningAppIcon from 'static/images/lightningapp.svg';
+import ZapAppIcon from 'static/images/zap.svg';
 import BTCPayServerIcon from 'static/images/btcpayserver.svg';
 import './SelectType.less';
 
@@ -37,6 +38,13 @@ export default class SelectType extends React.Component<Props> {
           onClick={() => onSelectNodeType(NODE_TYPE.LIGHTNING_APP)}
         >
           <Icon component={LightningAppIcon} /> Lightning App
+        </Button>
+        <Button
+          size="large"
+          block
+          onClick={() => onSelectNodeType(NODE_TYPE.ZAP_DESKTOP)}
+        >
+          <Icon component={ZapAppIcon} /> Zap Desktop
         </Button>
         <Button
           size="large"

--- a/src/app/static/images/zap.svg
+++ b/src/app/static/images/zap.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 47 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#202431" offset="0%"></stop>
+            <stop stop-color="#242633" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <circle id="Oval" fill="url(#linearGradient-1)" cx="23.5" cy="23.5" r="22.5"></circle>
+        <g id="zap" transform="translate(11.000000, 12.000000)">
+            <g id="cloud-lightning">
+                <path d="M20.1675725,17.361166 C22.9836776,16.803019 24.9083042,14.2528246 24.6195136,11.4621955 C24.330723,8.67156646 21.9224867,6.54856454 19.048913,6.5513834 L17.6394022,6.5513834 C16.6189158,2.69500403 13.055062,0.000740191543 8.97449933,0.000740230917 C4.8939367,0.000740270291 1.33008298,2.69500417 0.309596603,6.55138357 C-0.710889766,10.407763 1.07043321,14.4496153 4.64057971,16.3784585" id="Shape" stroke="#FFFFFF"></path>
+                <polyline id="Shape" stroke="#F5B300" points="13.455616 10.9189723 8.98097826 17.4703558 15.6929348 17.4703558 11.2182971 24.0217391"></polyline>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -9,12 +9,14 @@ export enum NODE_TYPE {
   LOCAL = 'LOCAL',
   REMOTE = 'REMOTE',
   LIGHTNING_APP = 'LIGHTNING_APP',
+  ZAP_DESKTOP = 'ZAP_DESKTOP',
   BTCPAY_SERVER = 'BTCPAY_SERVER',
 }
 
 export const DEFAULT_NODE_URLS = {
   [NODE_TYPE.LOCAL]: 'https://localhost:8080',
   [NODE_TYPE.LIGHTNING_APP]: 'https://localhost:8086',
+  [NODE_TYPE.ZAP_DESKTOP]: 'https://localhost:8180',
 } as { [key in NODE_TYPE]: string | undefined };
 
 interface LndDirectories  {
@@ -32,8 +34,13 @@ export const DEFAULT_LND_DIRS = {
   [NODE_TYPE.LIGHTNING_APP]: {
     MACOS: '~/Library/Application Support/lightning-app/lnd/data/chain/*',
     LINUX: '~/.config/lightning-app/lnd/data/chain/*',
-    WINDOWS: '%APPDATA%\\Roaming\\lightning-app\\lnd\\data\\chain\\*'
-  }
+    WINDOWS: '%APPDATA%\\Roaming\\lightning-app\\lnd\\data\\chain\\*',
+  },
+  [NODE_TYPE.ZAP_DESKTOP]: {
+    MACOS: '~/Library/Application Support/Zap/lnd/bitcoin/*',
+    LINUX: '~/.config/Zap/lnd/data/chain/*',
+    WINDOWS: '%APPDATA%\\Roaming\\Zap\\lnd\\data\\chain\\*',
+  },
 } as { [key in NODE_TYPE]: LndDirectories | undefined };
 
 export enum CHAIN_TYPE {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const packageJson = require('./package.json');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const hash = require('string-hash');
 
 // webpack plugins
 const CleanWebpackPlugin = require('clean-webpack-plugin');
@@ -57,16 +58,25 @@ const svgLoaderClient = {
   issuer: {
     test: /\.tsx?$/,
   },
-  use: [
-    {
-      loader: '@svgr/webpack',
-      options: {
-        svgoConfig: {
-          plugins: [{ inlineStyles: { onlyMatchedOnce: false } }],
-        },
+  use: ({ resource }) => ({
+    loader: '@svgr/webpack',
+    options: {
+      svgoConfig: {
+        plugins: [
+          {
+            inlineStyles: {
+              onlyMatchedOnce: false,
+            },
+          },
+          {
+            cleanupIDs: {
+              prefix: `svg-${hash(resource)}`,
+            },
+          },
+        ],
       },
     },
-  ], // svg -> react component
+  }), // svg -> react component
 };
 
 const urlLoaderClient = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10641,6 +10641,11 @@ string-convert@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
 
+string-hash@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
+  integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"


### PR DESCRIPTION
Closes #158

### Description

Adds a zap option to onboarding. Auto-connects to the 8180 port, and shows paths for the macaroons where Zap saves them. It's a little tricker, because zap supports multiple wallets and requires more rooting around in the file system. Hopefully there will be an easier way to get at these in the future.

Also fixes an issue with svgr that caused id collisions in svgs for things like gradients, and bumps up the icons a bit on the node type selection.

### Steps to Test

1. Run zap
2. Onboard with the zap option
3. Confirm it works as expected

### Screenshots

<img width="698" alt="Screen Shot 2019-03-20 at 2 54 08 PM" src="https://user-images.githubusercontent.com/649992/54711324-0f586a00-4b20-11e9-8dca-0308c8c7b3e5.png">

<img width="345" alt="Screen Shot 2019-03-20 at 2 54 16 PM" src="https://user-images.githubusercontent.com/649992/54711330-11222d80-4b20-11e9-887a-193b3b220070.png">
