### PR TITLE
Spoof error.error from error.message for LND 0.14.1+

### DIFF
--- a/src/app/lib/lnd-http/index.ts
+++ b/src/app/lib/lnd-http/index.ts
@@ -426,6 +426,12 @@ export class LndHttpClient {
           let errBody: any;
           try {
             errBody = await res.json();
+            // Breaking change in v0.14.1, res.error became res.message. Simply
+            // map it over for now.
+            if (errBody.message && !errBody.error) {
+              errBody.error = errBody.message;
+              delete errBody.message;
+            }
             if (!errBody.error) throw new Error();
           } catch (err) {
             throw new NetworkError(res.statusText, res.status);


### PR DESCRIPTION
Closes #291

### Description

Spoofs `error.error` string using new `error.message` string that replaced it as of 0.14.1. This seemed simpler than renaming `error.error` to `error.message` all over the codebase.

### Steps to Test

Go through onboarding, confirm that `getinfo` macaroon check works.
