### PR TITLE
Switch fee API provider to mempool.space

### DIFF
--- a/src/app/lib/fees.ts
+++ b/src/app/lib/fees.ts
@@ -1,4 +1,4 @@
-const API_URL = 'https://bitcoinfees.earn.com/api/v1/fees/recommended';
+const API_URL = 'https://mempool.space/api/v1/fees/recommended';
 
 export async function apiFetchOnChainFees() {
   const res = await fetch(API_URL);

--- a/src/app/modules/payment/sagas.ts
+++ b/src/app/modules/payment/sagas.ts
@@ -7,7 +7,7 @@ import {
 import { requirePassword } from 'modules/crypto/sagas';
 import { getAccountInfo, getTransactions } from 'modules/account/actions';
 import { checkPaymentRequest, sendPayment, createInvoice, sendOnChain } from './actions';
-import { apiFetchOnChainFees } from 'lib/earn';
+import { apiFetchOnChainFees } from 'lib/fees';
 import types from './types';
 import { CHAIN_TYPE } from 'utils/constants';
 import { NoRouteError } from 'lib/lnd-http/errors';


### PR DESCRIPTION
Closes #275

### Description

Switch fee provider from earn.com to mempool.space, rename file from `earn.ts` to `fees.ts` to remain provider-agnostic.

### Steps to Test

Go to send a bitcoin transaction or open a channel, confirm the fees aren't ridiculous.