### PR TITLE
Handle num_satoshis being '0' for any amount invoices

### DIFF
--- a/src/app/components/SendForm/LightningSend.tsx
+++ b/src/app/components/SendForm/LightningSend.tsx
@@ -122,10 +122,12 @@ class LightningSend extends React.Component<Props, State> {
         'seconds',
       );
     const hasExpired = expiry && expiry.isBefore(moment.now());
+    const num_satoshis = requestData.data?.request.num_satoshis;
     const disabled =
       !requestData.data ||
       !!hasExpired ||
-      (!requestData.data.request.num_satoshis && !value);
+      (!num_satoshis && !value) ||
+      (num_satoshis === '0' && !value);
 
     return (
       <Form className="LightningSend" onSubmit={this.handleSubmit}>
@@ -179,7 +181,7 @@ class LightningSend extends React.Component<Props, State> {
                 </code>
               </div>
             </div>
-            {!routedRequest.request.num_satoshis && (
+            {(!num_satoshis || num_satoshis === '0') && (
               <div className="LightningSend-payment-value">
                 <Input.Group compact>
                   <Input
@@ -209,11 +211,11 @@ class LightningSend extends React.Component<Props, State> {
               <div className="LightningSend-payment-details">
                 <table>
                   <tbody>
-                    {routedRequest.request.num_satoshis && (
+                    {num_satoshis && (
                       <tr>
                         <td>Amount</td>
                         <td>
-                          <Unit value={routedRequest.request.num_satoshis} />
+                          <Unit value={num_satoshis} />
                         </td>
                       </tr>
                     )}

--- a/src/app/prompts/payment.tsx
+++ b/src/app/prompts/payment.tsx
@@ -74,11 +74,9 @@ class PaymentPrompt extends React.Component<Props, State> {
         isLatestRoute: !!this.state.routedRequest,
       });
 
-      if (newPr.data.request.num_satoshis) {
-        const value = fromBaseToUnit(
-          newPr.data.request.num_satoshis,
-          denomination,
-        ).toString();
+      const { num_satoshis } = newPr.data.request;
+      if (num_satoshis && num_satoshis !== '0') {
+        const value = fromBaseToUnit(num_satoshis, denomination).toString();
         this.setState({
           value,
           // ...but if a payment came with the request, it's a latest route
@@ -122,7 +120,7 @@ class PaymentPrompt extends React.Component<Props, State> {
           <NodeInfo pubkey={node.pub_key} alias={node.alias} />
           <div className="PaymentPrompt-amount">
             <h4 className="PaymentPrompt-amount-label">Amount</h4>
-            {request.num_satoshis ? (
+            {request.num_satoshis && request.num_satoshis !== '0' ? (
               <div className="PaymentPrompt-amount-value">
                 <Unit value={request.num_satoshis} showFiat />
               </div>


### PR DESCRIPTION
Closes #285

### Description

Handles a change in the LND API that now returns `'0`' for `num_satoshis` on requests, rather than previously being falsy. Also handles that query routes no longer works with zero amounts.

### Steps to Test

1. Generate a zero amount invoice
2. Run `webln.sendPayment("...")` with the invoice, confirm you get an input
3. Change the value, confirm you get fee and route information
3. Open the extension and attempt to send to the zero amount invoice, confirm you get an input
3. Change the value, confirm you get fee and route information
