### PR TITLE
Fix payment node identities

### DIFF
--- a/src/app/lib/lnd-http/types.ts
+++ b/src/app/lib/lnd-http/types.ts
@@ -119,6 +119,7 @@ export interface Hop {
   fee_msat: string;
   chan_capacity: string;
   amt_to_forward: string;
+  pub_key: string;
 }
 
 export interface Route {
@@ -141,6 +142,12 @@ export interface ChainTransaction {
   block_hash: string;
 }
 
+export interface HTLCAttempt {
+  attempt_id: string;
+  status: string;
+  route: Route;
+}
+
 export interface LightningPayment {
   payment_hash: string;
   fee: string;
@@ -148,7 +155,8 @@ export interface LightningPayment {
   value_sat: string;
   value_msat: string;
   payment_preimage: string;
-  path: string[];
+  path?: string[];
+  htlcs?: HTLCAttempt[];
 }
 
 export interface LightningInvoice {

--- a/src/app/utils/lnd-shims.ts
+++ b/src/app/utils/lnd-shims.ts
@@ -7,7 +7,7 @@
 import { Hop, LightningPayment } from 'lib/lnd-http';
 
 export function getPaymentHops(payment: LightningPayment) {
-  let path: Array<Partial<Hop>> = [];
+  let path: Partial<Hop>[] = [];
   if (payment.htlcs?.[0]) {
     path = payment.htlcs[0].route.hops;
   } else if (payment.path) {

--- a/src/app/utils/lnd-shims.ts
+++ b/src/app/utils/lnd-shims.ts
@@ -1,0 +1,24 @@
+/**
+ * @file
+ * These utilities provide convenient ways to handle API responses from
+ * multiple versions of LND.
+ */
+
+import { Hop, LightningPayment } from 'lib/lnd-http';
+
+export function getPaymentHops(payment: LightningPayment) {
+  let path: Array<Partial<Hop>> = [];
+  if (payment.htlcs?.[0]) {
+    path = payment.htlcs[0].route.hops;
+  } else if (payment.path) {
+    path = payment.path.map(p => ({
+      pub_key: p,
+    }));
+  }
+  return path;
+}
+
+export function getPaymentRecipientPubkey(payment: LightningPayment) {
+  const path = getPaymentHops(payment);
+  return path[path.length - 1].pub_key;
+}


### PR DESCRIPTION
Closes #256

### Description

Fixes the payments fetching API code to leverage the new `htlcs` key on payments to identify the node you paid to. This code should handle both old node responses and new ones.

### Steps to Test

Open your list of payments, you should see most of the nodes that they're associated with again.