### PR TITLE
Adding github action for automated submission

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,29 @@
+name: Submit
+
+on:
+  workflow_dispatch:
+    inputs: 
+      tag:
+        description: 'Release tag to submit, i.e v1.0.0'
+        required: true
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: latest
+      - name: Download Github Release Assets
+        uses: plasmo-corp/download-release-asset@v1.0.0
+        with:
+          files: joule-*
+          tag: ${{ github.event.inputs.tag }}
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        env:
+          PUPPETEER_EXECUTABLE_PATH: /opt/hostedtoolcache/chromium/latest/x64/chrome
+        with:
+          artifact: "joule-${{ github.event.inputs.tag }}.zip"
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ tmp/
 .vscode
 
 .idea/
+
+keys.json


### PR DESCRIPTION
<!-- New to the project? Check out the Contributor Guidelines! -->
<!-- https://github.com/wbobeirne/joule-extension/wiki/Contributor-Guidelines -->

Related #260 

### Description

I found that joule doesn't have the store submission pipeline automated yet. This PR creates a `Submit` workflow to automate the zip submission process to Chrome/Firefox/Edge stores automatically, using [bpp](https://browser.market/) . It is set to run manually from the github action tab with a `tag` input, but we can tweak it to be even more granular as needed! The only thing that is needed is to create is a `SUBMIT_KEYS` github repository secret.

The `SUBMIT_KEYS` secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/v1/keys.schema.json).

Here's a sample key for every stores:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
	"firefox": {
		"apiKey": "123",
		"apiSecret": "789",
		"extId": "abcd"
	},
	"edge": {
		"cookie": "123",
		"extId": "abcd"
	},
	"opera": {
		"sessionid": "123",
		"csrftoken": "789",
		"packageId": 0
	}
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)

### How it works

1. Via the `tag` input, it downloads the release assets associated with that tag from github
2. Then, it uploads the `joule-{tag}.zip` file to each store. For chrome it uses the webstore API. For firefox, it uses sign-addon (https://github.com/mozilla/sign-addon). For Opera and Edge, it uses Puppeteer to run a headless chrome instance to upload the zip files.

### Steps to Test

1. Fork this PR, and setup some test store items
2. Go to github action tab
3. Run the action manually with the latest tag
