### PR TITLE
Remove unused active tab permission

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -32,7 +32,7 @@
     "persistent": true
   },
   "web_accessible_resources": ["inpage_script.js"],
-  "permissions": ["storage", "clipboardWrite", "activeTab", "contextMenus"],
+  "permissions": ["storage", "clipboardWrite", "contextMenus"],
   "optional_permissions": ["notifications", "http://*/", "https://*/"],
   "applications": {
     "gecko": {


### PR DESCRIPTION
### Description

Removes the `activeTab` permission since it was unused, and Google doesn't like you asking for permissions that you aren't actively using.
